### PR TITLE
docs: 未作成ドキュメント参照を削除し Phase 1 完了後に作成する方針を明記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,6 @@
 
 ## Architecture Patterns
 
-詳細は `.claude/architecture.md` を参照してください。
-
 ### Server Actions
 
 - **配置**: `app/_actions/{domain}.ts`
@@ -49,8 +47,6 @@
 - **データ取得**: Server Actions を呼び出し
 
 ## Security
-
-詳細は `.claude/security.md` を参照してください。
 
 ### エラーハンドリング
 
@@ -144,9 +140,6 @@ const results = await classifyTransactions(transactions);
 
 ## Task Guidelines
 
-- 機能追加時: `.claude/architecture.md` を参照
-- テスト作成時: `.claude/testing.md` を参照
-- セキュリティ作業: `.claude/security.md` を参照
 - コード例: `.claude/examples.md` を参照
 - タスクチェックリスト: `.claude/task-checklists.md` を参照
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -172,6 +172,16 @@ feat: プロフィール設定画面（会計年度開始月、デフォルト�
 - 推定変更ファイル数: 5ファイル
 ```
 
+### Phase 1 完了時の追加タスク
+
+Phase 1 の実装コードが揃った段階で、以下のドキュメントを実コードに基づいて作成する:
+
+- `.claude/architecture.md` — Data Flow、File Structure、Server Action/DB/Clientのパターン集
+- `.claude/security.md` — 脆弱性パターン（IDOR, Mass Assignment等）、モック例
+- `.claude/testing.md` — TDDワークフロー詳細、モックパターン集、テストコード例
+
+※実装前に書くと実態と乖離するため、Phase 1 完了後に実コードをベースに作成する。
+
 ---
 
 ## 🎨 デザイン設計セッション [半日〜1日]


### PR DESCRIPTION
## 概要

Closes #3

- CLAUDE.md から未作成の `.claude/{architecture,security,testing}.md` への参照を削除
- `docs/IMPLEMENTATION_PLAN.md` に Phase 1 完了後の追加タスクとして記載

## 変更理由

実装前にドキュメントを書くと実態と乖離するため、Phase 1 の実装コードが揃った段階で
実コードに基づいて architecture.md / security.md / testing.md を作成する方針に変更。

## 変更内容

- **CLAUDE.md**: `architecture.md`, `security.md`, `testing.md` への参照（5箇所）を削除
- **docs/IMPLEMENTATION_PLAN.md**: Issue #8 の後に「Phase 1 完了時の追加タスク」セクションを追加

## テスト結果

- TypeScript: ✅ 通過
- Lint: ✅ 変更対象の .md は Biome 対象外（既存 CRLF エラーは別 Issue）
- Unit Tests: ✅ 22 tests passed (2 files)
- Coverage: 既存テストに影響なし

## サイズ

- 2 files changed, 10 insertions(+), 7 deletions(-)

## TDDチェックリスト

- [x] ドキュメントのみの変更のためTDD対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)