### PR TITLE
test: handleApiError + transaction validator テスト追加

### DIFF
--- a/lib/validators/__tests__/transaction.test.ts
+++ b/lib/validators/__tests__/transaction.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+	aiClassifyRequestSchema,
+	createTransactionSchema,
+	updateTransactionSchema,
+} from "@/lib/validators/transaction";
+
+describe("createTransactionSchema", () => {
+	// 正常系
+	it("有効な取引データを受け入れる", () => {
+		const input = {
+			transactionDate: "2026-03-01",
+			description: "AWS利用料",
+			amount: 5000,
+			debitAccount: "EXP001",
+			creditAccount: "AST002",
+			taxCategory: "tax_10",
+			memo: "3月分",
+		};
+		const result = createTransactionSchema.safeParse(input);
+		expect(result.success).toBe(true);
+	});
+
+	it("任意フィールドなしでも受け入れる", () => {
+		const input = {
+			transactionDate: "2026-01-15",
+			description: "電車代",
+			amount: 330,
+			debitAccount: "EXP003",
+			creditAccount: "AST001",
+		};
+		const result = createTransactionSchema.safeParse(input);
+		expect(result.success).toBe(true);
+	});
+
+	it("descriptionの前後空白をトリムする", () => {
+		const input = {
+			transactionDate: "2026-01-15",
+			description: "  電車代  ",
+			amount: 330,
+			debitAccount: "EXP003",
+			creditAccount: "AST001",
+		};
+		const result = createTransactionSchema.safeParse(input);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.description).toBe("電車代");
+		}
+	});
+
+	// 異常系
+	it("不正な日付形式を拒否する", () => {
+		const input = {
+			transactionDate: "2026/03/01",
+			description: "テスト",
+			amount: 1000,
+			debitAccount: "EXP001",
+			creditAccount: "AST002",
+		};
+		const result = createTransactionSchema.safeParse(input);
+		expect(result.success).toBe(false);
+	});
+
+	it("負の金額を拒否する", () => {
+		const input = {
+			transactionDate: "2026-03-01",
+			description: "テスト",
+			amount: -500,
+			debitAccount: "EXP001",
+			creditAccount: "AST002",
+		};
+		const result = createTransactionSchema.safeParse(input);
+		expect(result.success).toBe(false);
+	});
+
+	it("無効な勘定科目コードを拒否する", () => {
+		const input = {
+			transactionDate: "2026-03-01",
+			description: "テスト",
+			amount: 1000,
+			debitAccount: "INVALID_CODE",
+			creditAccount: "AST002",
+		};
+		const result = createTransactionSchema.safeParse(input);
+		expect(result.success).toBe(false);
+	});
+
+	it("空の摘要を拒否する", () => {
+		const input = {
+			transactionDate: "2026-03-01",
+			description: "",
+			amount: 1000,
+			debitAccount: "EXP001",
+			creditAccount: "AST002",
+		};
+		const result = createTransactionSchema.safeParse(input);
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("updateTransactionSchema", () => {
+	it("IDと部分更新を受け入れる", () => {
+		const input = {
+			id: "550e8400-e29b-41d4-a716-446655440000",
+			isConfirmed: true,
+		};
+		const result = updateTransactionSchema.safeParse(input);
+		expect(result.success).toBe(true);
+	});
+
+	it("無効なUUID形式のIDを拒否する", () => {
+		const input = {
+			id: "not-a-uuid",
+			isConfirmed: true,
+		};
+		const result = updateTransactionSchema.safeParse(input);
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("aiClassifyRequestSchema", () => {
+	it("1〜50件の取引リクエストを受け入れる", () => {
+		const input = {
+			transactions: [{ date: "2026-03-01", description: "AWS", amount: 5000 }],
+		};
+		const result = aiClassifyRequestSchema.safeParse(input);
+		expect(result.success).toBe(true);
+	});
+
+	it("空の取引配列を拒否する", () => {
+		const input = { transactions: [] };
+		const result = aiClassifyRequestSchema.safeParse(input);
+		expect(result.success).toBe(false);
+	});
+
+	it("51件以上の取引を拒否する", () => {
+		const transactions = Array.from({ length: 51 }, (_, i) => ({
+			date: "2026-03-01",
+			description: `取引${i}`,
+			amount: 1000,
+		}));
+		const input = { transactions };
+		const result = aiClassifyRequestSchema.safeParse(input);
+		expect(result.success).toBe(false);
+	});
+});

--- a/tests/unit/lib/__tests__/api-error.test.ts
+++ b/tests/unit/lib/__tests__/api-error.test.ts
@@ -75,4 +75,19 @@ describe("handleApiError", () => {
 			expect(result.code).toBe("INTERNAL_ERROR");
 		}
 	});
+
+	it("Supabaseその他DBエラーを汎用メッセージに変換する", () => {
+		const supabaseError = {
+			code: "P0001",
+			message: "internal database exception with sensitive info",
+		};
+		const result = handleApiError(supabaseError);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).toBe("データベースエラーが発生しました。");
+			expect(result.code).toBe("INTERNAL_ERROR");
+			expect(result.error).not.toContain("sensitive");
+		}
+	});
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,7 +29,6 @@ export default defineConfig({
 				"lib/types/**",
 				"lib/**/*.d.ts",
 				"lib/utils/constants.ts",
-				"lib/validators/**",
 				"app/layout.tsx",
 				"app/page.tsx",
 			],


### PR DESCRIPTION
## 概要

Closes #5

TDD ワークフローに基づき、handleApiError と transaction validator のテストを追加。
既存実装のテストカバレッジを Issue 要件（error.ts ≥ 90%, transaction.ts ≥ 85%）以上に引き上げた。

## 変更内容

- `tests/unit/lib/__tests__/api-error.test.ts`: 7テストケース（+1: Supabaseその他DBエラー）
- `lib/validators/__tests__/transaction.test.ts`: 12テストケース新規作成
  - createTransactionSchema: 正常系3 + 異常系4
  - updateTransactionSchema: 正常系1 + 異常系1
  - aiClassifyRequestSchema: 正常系1 + 異常系2
- `vitest.config.ts`: `lib/validators/**` をカバレッジ計測対象に復帰

## テスト結果

- TypeScript: ✅ 通過
- Lint: ✅ 通過 (20 files)
- Unit Tests: ✅ 35 tests passed (3 files)
- Coverage:

| ファイル | Stmts | Branch | Funcs | Lines | 要件 |
|---------|-------|--------|-------|-------|------|
| error.ts | 100% | 100% | 100% | 100% | ≥ 90% ✅ |
| transaction.ts | 100% | 100% | 100% | 100% | ≥ 85% ✅ |
| 全体 | 92.59% | 91.89% | 100% | 92.45% | ≥ 80% ✅ |

## サイズ

- 3 files changed, 161 insertions(+), 1 deletion(-)

## TDDチェックリスト

- [x] 🔴 RED: テストを先に記述
- [x] 🟢 GREEN: 既存実装が全テストをパス（追加実装不要）
- [x] 🔵 REFACTOR: validators をカバレッジ対象に復帰、import 順序修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)