### PR TITLE
fix: build ジョブの依存を test に戻す（テスト基盤整備完了）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: typecheck
+    needs: test
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- build ジョブの `needs` を `typecheck` から `test` に変更
- テスト基盤（Issue #5）が整備完了したため、build はテスト通過後に実行するよう修正

## Changes
- `.github/workflows/ci.yml`: build ジョブの `needs: typecheck` → `needs: test`

## CI パイプライン（変更後）
```
lint → typecheck → test → build
                 ↘ security
```

## Test plan
- [ ] CI パイプラインが正しい順序で実行されることを確認
- [ ] build ジョブが test ジョブ完了後に開始することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)