### PR TITLE
feat: 認証基盤（Supabase Auth + ミドルウェア）

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,23 @@
+import type { User } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/server";
+import type { ApiResponse } from "@/lib/types/api";
+
+export async function getUser(): Promise<User | null> {
+	const supabase = await createClient();
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+	return user;
+}
+
+export async function requireAuth(): Promise<ApiResponse<User>> {
+	const user = await getUser();
+	if (!user) {
+		return {
+			success: false,
+			error: "ログインが必要です。",
+			code: "UNAUTHORIZED",
+		};
+	}
+	return { success: true, data: user };
+}

--- a/lib/auth/__tests__/auth.test.ts
+++ b/lib/auth/__tests__/auth.test.ts
@@ -1,0 +1,130 @@
+import type { User } from "@supabase/supabase-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Supabase server client をモック
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(),
+}));
+
+import { getUser, requireAuth } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+const mockGetUser = vi.fn();
+const mockCreateClient = vi.mocked(createClient);
+
+const mockUser: Pick<
+	User,
+	"id" | "email" | "app_metadata" | "user_metadata" | "aud" | "created_at"
+> = {
+	id: "user-123",
+	email: "test@example.com",
+	app_metadata: {},
+	user_metadata: {},
+	aud: "authenticated",
+	created_at: "2026-01-01T00:00:00Z",
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockCreateClient.mockResolvedValue({
+		auth: { getUser: mockGetUser },
+	} as unknown as Awaited<ReturnType<typeof createClient>>);
+});
+
+describe("getUser", () => {
+	it("認証済みユーザーの情報を返す", async () => {
+		mockGetUser.mockResolvedValue({
+			data: { user: mockUser },
+			error: null,
+		});
+
+		const user = await getUser();
+
+		expect(user).toEqual(mockUser);
+	});
+
+	it("未認証の場合 null を返す", async () => {
+		mockGetUser.mockResolvedValue({
+			data: { user: null },
+			error: null,
+		});
+
+		const user = await getUser();
+
+		expect(user).toBeNull();
+	});
+
+	it("認証エラーの場合 null を返す", async () => {
+		mockGetUser.mockResolvedValue({
+			data: { user: null },
+			error: { message: "Invalid token", status: 401 },
+		});
+
+		const user = await getUser();
+
+		expect(user).toBeNull();
+	});
+});
+
+describe("requireAuth", () => {
+	it("認証済みユーザーで ApiResponse success を返す", async () => {
+		mockGetUser.mockResolvedValue({
+			data: { user: mockUser },
+			error: null,
+		});
+
+		const result = await requireAuth();
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.id).toBe("user-123");
+			expect(result.data.email).toBe("test@example.com");
+		}
+	});
+
+	it("未認証の場合 UNAUTHORIZED エラーを返す", async () => {
+		mockGetUser.mockResolvedValue({
+			data: { user: null },
+			error: null,
+		});
+
+		const result = await requireAuth();
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("UNAUTHORIZED");
+			expect(result.error).toBe("ログインが必要です。");
+		}
+	});
+
+	it("セッション切れの場合 UNAUTHORIZED エラーを返す", async () => {
+		mockGetUser.mockResolvedValue({
+			data: { user: null },
+			error: { message: "Session expired", status: 401 },
+		});
+
+		const result = await requireAuth();
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("UNAUTHORIZED");
+			// 内部エラーメッセージが漏れないことを確認
+			expect(result.error).not.toContain("Session expired");
+		}
+	});
+
+	it("エラーメッセージに内部情報を含まない", async () => {
+		mockGetUser.mockResolvedValue({
+			data: { user: null },
+			error: { message: "JWT expired at 2026-01-01", status: 401 },
+		});
+
+		const result = await requireAuth();
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).not.toContain("JWT");
+			expect(result.error).not.toContain("2026");
+		}
+	});
+});

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,11 @@
+import { createBrowserClient } from "@supabase/ssr";
+import type { Database } from "@/lib/types/supabase";
+
+export function createClient() {
+	// biome-ignore lint/style/noNonNullAssertion: 環境変数は .env.local で必須設定済み
+	const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+	// biome-ignore lint/style/noNonNullAssertion: 環境変数は .env.local で必須設定済み
+	const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+	return createBrowserClient<Database>(supabaseUrl, supabaseAnonKey);
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,0 +1,45 @@
+import { createServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function updateSession(request: NextRequest) {
+	let supabaseResponse = NextResponse.next({ request });
+
+	// biome-ignore lint/style/noNonNullAssertion: 環境変数は .env.local で必須設定済み
+	const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+	// biome-ignore lint/style/noNonNullAssertion: 環境変数は .env.local で必須設定済み
+	const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+	const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+		cookies: {
+			getAll() {
+				return request.cookies.getAll();
+			},
+			setAll(cookiesToSet) {
+				for (const { name, value } of cookiesToSet) {
+					request.cookies.set(name, value);
+				}
+				supabaseResponse = NextResponse.next({ request });
+				for (const { name, value, options } of cookiesToSet) {
+					supabaseResponse.cookies.set(name, value, options);
+				}
+			},
+		},
+	});
+
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	// 未認証ユーザーをログインページにリダイレクト
+	// 公開ページ（/, /login, /signup）はスキップ
+	const publicPaths = ["/", "/login", "/signup"];
+	const isPublicPath = publicPaths.some((path) => request.nextUrl.pathname === path);
+
+	if (!user && !isPublicPath) {
+		const url = request.nextUrl.clone();
+		url.pathname = "/login";
+		return NextResponse.redirect(url);
+	}
+
+	return supabaseResponse;
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,25 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import type { Database } from "@/lib/types/supabase";
+
+export async function createClient() {
+	const cookieStore = await cookies();
+
+	// biome-ignore lint/style/noNonNullAssertion: 環境変数は .env.local で必須設定済み
+	const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+	// biome-ignore lint/style/noNonNullAssertion: 環境変数は .env.local で必須設定済み
+	const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+	return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+		cookies: {
+			getAll() {
+				return cookieStore.getAll();
+			},
+			setAll(cookiesToSet) {
+				for (const { name, value, options } of cookiesToSet) {
+					cookieStore.set(name, value, options);
+				}
+			},
+		},
+	});
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from "next/server";
+import { updateSession } from "@/lib/supabase/middleware";
+
+export async function middleware(request: NextRequest) {
+	return await updateSession(request);
+}
+
+export const config = {
+	matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
 				"lib/types/**",
 				"lib/**/*.d.ts",
 				"lib/utils/constants.ts",
+				"lib/supabase/**",
 				"app/layout.tsx",
 				"app/page.tsx",
 			],


### PR DESCRIPTION
## Summary
- Supabase Auth を使用した認証基盤を構築
- `getUser()` / `requireAuth()` で統一的な認証チェックを提供
- ミドルウェアによるセッション自動更新と未認証リダイレクト

## Changes
| ファイル | 概要 |
|---------|------|
| `lib/auth.ts` | `getUser()` / `requireAuth()` 認証ユーティリティ |
| `lib/supabase/server.ts` | サーバーサイド Supabase クライアント（Cookie 連携） |
| `lib/supabase/client.ts` | ブラウザ用 Supabase クライアント |
| `lib/supabase/middleware.ts` | セッション更新 + 認証ルーティング |
| `middleware.ts` | Next.js ミドルウェア（公開ページ以外をガード） |
| `lib/auth/__tests__/auth.test.ts` | 7テストケース（TDD で作成） |
| `vitest.config.ts` | `lib/supabase/**` をカバレッジ除外に追加 |

## Test plan
- [x] `npm run typecheck` — 型エラー 0件
- [x] `npm run lint` — Biome エラー 0件
- [x] `npm run test:unit` — 42テスト全通過
- [x] カバレッジ: auth.ts 100% / 全体 Statements 93.44%, Branches 92.3%, Functions 100%, Lines 93.33%
- [x] TDD Red-Green-Refactor サイクル完了

## テストケース詳細
1. 認証済みユーザーの情報を返す（getUser）
2. 未認証の場合 null を返す（getUser）
3. 認証エラーの場合 null を返す（getUser）
4. 認証済みユーザーで ApiResponse success を返す（requireAuth）
5. 未認証の場合 UNAUTHORIZED エラーを返す（requireAuth）
6. セッション切れの場合 UNAUTHORIZED エラーを返す（requireAuth）
7. エラーメッセージに内部情報を含まない（requireAuth）

## PR Size
- 7 files changed, 245 insertions

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)