### PR TITLE
feat: 認証 Server Actions + バリデーション（Issue #7 前半）

### DIFF
--- a/app/_actions/__tests__/auth.test.ts
+++ b/app/_actions/__tests__/auth.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+	revalidatePath: vi.fn(),
+}));
+
+import { signIn, signInWithGoogle, signOut, signUp } from "@/app/_actions/auth";
+import { createClient } from "@/lib/supabase/server";
+
+const mockSignInWithPassword = vi.fn();
+const mockSignUp = vi.fn();
+const mockSignOut = vi.fn();
+const mockSignInWithOAuth = vi.fn();
+const mockCreateClient = vi.mocked(createClient);
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockCreateClient.mockResolvedValue({
+		auth: {
+			signInWithPassword: mockSignInWithPassword,
+			signUp: mockSignUp,
+			signOut: mockSignOut,
+			signInWithOAuth: mockSignInWithOAuth,
+		},
+	} as unknown as Awaited<ReturnType<typeof createClient>>);
+});
+
+function createFormData(data: Record<string, string>): FormData {
+	const fd = new FormData();
+	for (const [key, value] of Object.entries(data)) {
+		fd.set(key, value);
+	}
+	return fd;
+}
+
+describe("signIn", () => {
+	it("有効な認証情報でログイン成功", async () => {
+		mockSignInWithPassword.mockResolvedValue({ error: null });
+
+		const result = await signIn(
+			createFormData({ email: "test@example.com", password: "password123" }),
+		);
+
+		expect(result.success).toBe(true);
+		expect(mockSignInWithPassword).toHaveBeenCalledWith({
+			email: "test@example.com",
+			password: "password123",
+		});
+	});
+
+	it("無効な認証情報でエラーを返す", async () => {
+		mockSignInWithPassword.mockResolvedValue({
+			error: { message: "Invalid login credentials" },
+		});
+
+		const result = await signIn(createFormData({ email: "test@example.com", password: "wrong" }));
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("UNAUTHORIZED");
+			expect(result.error).not.toContain("Invalid login credentials");
+		}
+	});
+
+	it("空のメールアドレスでバリデーションエラー", async () => {
+		const result = await signIn(createFormData({ email: "", password: "password123" }));
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("VALIDATION_ERROR");
+		}
+		expect(mockSignInWithPassword).not.toHaveBeenCalled();
+	});
+});
+
+describe("signUp", () => {
+	it("有効なデータでサインアップ成功", async () => {
+		mockSignUp.mockResolvedValue({ error: null });
+
+		const result = await signUp(
+			createFormData({ email: "new@example.com", password: "password123" }),
+		);
+
+		expect(result.success).toBe(true);
+		expect(mockSignUp).toHaveBeenCalledWith({
+			email: "new@example.com",
+			password: "password123",
+		});
+	});
+
+	it("短いパスワードでバリデーションエラー", async () => {
+		const result = await signUp(createFormData({ email: "new@example.com", password: "short" }));
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("VALIDATION_ERROR");
+		}
+		expect(mockSignUp).not.toHaveBeenCalled();
+	});
+
+	it("既存メールアドレスでエラーを返す", async () => {
+		mockSignUp.mockResolvedValue({
+			error: { message: "User already registered" },
+		});
+
+		const result = await signUp(
+			createFormData({ email: "existing@example.com", password: "password123" }),
+		);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).not.toContain("User already registered");
+		}
+	});
+});
+
+describe("signInWithGoogle", () => {
+	it("OAuth URLを返す", async () => {
+		mockSignInWithOAuth.mockResolvedValue({
+			data: { url: "https://accounts.google.com/o/oauth2/auth?..." },
+			error: null,
+		});
+
+		const result = await signInWithGoogle();
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.url).toContain("https://");
+		}
+	});
+
+	it("OAuth エラー時にエラーを返す", async () => {
+		mockSignInWithOAuth.mockResolvedValue({
+			data: { url: null },
+			error: { message: "OAuth provider error" },
+		});
+
+		const result = await signInWithGoogle();
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).not.toContain("OAuth provider error");
+		}
+	});
+});
+
+describe("signOut", () => {
+	it("ログアウト成功", async () => {
+		mockSignOut.mockResolvedValue({ error: null });
+
+		const result = await signOut();
+
+		expect(result.success).toBe(true);
+		expect(mockSignOut).toHaveBeenCalled();
+	});
+});

--- a/app/_actions/auth.ts
+++ b/app/_actions/auth.ts
@@ -1,0 +1,108 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { handleApiError } from "@/lib/api/error";
+import { createClient } from "@/lib/supabase/server";
+import type { ApiResponse } from "@/lib/types/api";
+import { loginSchema, signupSchema } from "@/lib/validators/auth";
+
+export async function signIn(formData: FormData): Promise<ApiResponse<null>> {
+	try {
+		const parsed = loginSchema.safeParse({
+			email: formData.get("email"),
+			password: formData.get("password"),
+		});
+
+		if (!parsed.success) {
+			return {
+				success: false,
+				error: "メールアドレスとパスワードを正しく入力してください。",
+				code: "VALIDATION_ERROR",
+			};
+		}
+
+		const supabase = await createClient();
+		const { error } = await supabase.auth.signInWithPassword(parsed.data);
+
+		if (error) {
+			return {
+				success: false,
+				error: "メールアドレスまたはパスワードが正しくありません。",
+				code: "UNAUTHORIZED",
+			};
+		}
+
+		revalidatePath("/", "layout");
+		return { success: true, data: null };
+	} catch (error) {
+		return handleApiError(error);
+	}
+}
+
+export async function signUp(formData: FormData): Promise<ApiResponse<null>> {
+	try {
+		const parsed = signupSchema.safeParse({
+			email: formData.get("email"),
+			password: formData.get("password"),
+		});
+
+		if (!parsed.success) {
+			return {
+				success: false,
+				error: "メールアドレスとパスワード（8文字以上）を入力してください。",
+				code: "VALIDATION_ERROR",
+			};
+		}
+
+		const supabase = await createClient();
+		const { error } = await supabase.auth.signUp(parsed.data);
+
+		if (error) {
+			return {
+				success: false,
+				error: "アカウントの作成に失敗しました。",
+				code: "INTERNAL_ERROR",
+			};
+		}
+
+		revalidatePath("/", "layout");
+		return { success: true, data: null };
+	} catch (error) {
+		return handleApiError(error);
+	}
+}
+
+export async function signInWithGoogle(): Promise<ApiResponse<{ url: string }>> {
+	try {
+		const supabase = await createClient();
+		const { data, error } = await supabase.auth.signInWithOAuth({
+			provider: "google",
+			options: {
+				redirectTo: `${process.env.NEXT_PUBLIC_SUPABASE_URL ? new URL("/auth/callback", process.env.NEXT_PUBLIC_SUPABASE_URL.replace(".supabase.co", "")).href : "/auth/callback"}`,
+			},
+		});
+
+		if (error || !data.url) {
+			return {
+				success: false,
+				error: "Google認証の開始に失敗しました。",
+				code: "INTERNAL_ERROR",
+			};
+		}
+
+		return { success: true, data: { url: data.url } };
+	} catch (error) {
+		return handleApiError(error);
+	}
+}
+
+export async function signOut(): Promise<ApiResponse<null>> {
+	try {
+		const supabase = await createClient();
+		await supabase.auth.signOut();
+		revalidatePath("/", "layout");
+		return { success: true, data: null };
+	} catch (error) {
+		return handleApiError(error);
+	}
+}

--- a/lib/validators/auth.ts
+++ b/lib/validators/auth.ts
@@ -1,0 +1,11 @@
+import { z } from "zod/v4";
+
+export const loginSchema = z.object({
+	email: z.email("有効なメールアドレスを入力してください。"),
+	password: z.string().min(1, "パスワードを入力してください。"),
+});
+
+export const signupSchema = z.object({
+	email: z.email("有効なメールアドレスを入力してください。"),
+	password: z.string().min(8, "パスワードは8文字以上で入力してください。"),
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
 		include: [
 			"lib/**/__tests__/**/*.test.ts",
 			"lib/**/__tests__/**/*.test.tsx",
+			"app/**/__tests__/**/*.test.ts",
+			"app/**/__tests__/**/*.test.tsx",
 			"tests/unit/**/*.test.ts",
 			"tests/integration/**/*.test.ts",
 		],
@@ -30,8 +32,9 @@ export default defineConfig({
 				"lib/**/*.d.ts",
 				"lib/utils/constants.ts",
 				"lib/supabase/**",
-				"app/layout.tsx",
-				"app/page.tsx",
+				"app/**/page.tsx",
+				"app/**/layout.tsx",
+				"app/**/route.ts",
 			],
 			thresholds: {
 				statements: 80,


### PR DESCRIPTION
## Summary
- 認証用 Server Actions（signIn / signUp / signInWithGoogle / signOut）を実装
- Zod バリデーションスキーマ（login / signup）を追加
- TDD で 9 テストケースを作成

## Changes
| ファイル | 概要 |
|---------|------|
| `app/_actions/auth.ts` | 認証 Server Actions（ApiResponse<T> 準拠） |
| `lib/validators/auth.ts` | login/signup Zod スキーマ |
| `app/_actions/__tests__/auth.test.ts` | 9 テストケース |
| `vitest.config.ts` | `app/**/__tests__` パターン追加 + カバレッジ除外更新 |

## Test plan
- [x] `npm run typecheck` — 型エラー 0件
- [x] `npm run lint` — Biome エラー 0件
- [x] `npm run test:unit` — 51テスト全通過
- [x] カバレッジ: auth.ts(actions) 88.57% / auth.ts(validators) 100% / 全体 91.83%
- [x] `npm run build` — ビルド成功
- [x] TDD Red-Green-Refactor サイクル完了

## テストケース詳細
**signIn (3)**
1. 有効な認証情報でログイン成功
2. 無効な認証情報でエラー（内部メッセージ非露出）
3. 空メールアドレスでバリデーションエラー

**signUp (3)**
4. 有効なデータでサインアップ成功
5. 短いパスワードでバリデーションエラー
6. 既存メールアドレスでエラー（内部メッセージ非露出）

**signInWithGoogle (2)**
7. OAuth URL を正常に返す
8. OAuth エラー時にエラーを返す

**signOut (1)**
9. ログアウト成功

## PR Size
- 4 files changed, 284 insertions(+), 2 deletions(-)

## Note
Issue #7 を2つの PR に分割:
- **この PR**: Server Actions + バリデーション + テスト
- **次の PR**: ログイン UI + OAuth コールバック + ダッシュボード

🤖 Generated with [Claude Code](https://claude.com/claude-code)