### PR TITLE
feat: ログイン画面 + OAuth コールバック + ダッシュボード（Issue #7 後半）

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(request: Request) {
+	const { searchParams, origin } = new URL(request.url);
+	const code = searchParams.get("code");
+
+	if (code) {
+		const supabase = await createClient();
+		await supabase.auth.exchangeCodeForSession(code);
+	}
+
+	return NextResponse.redirect(`${origin}/dashboard`);
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+import { getUser } from "@/lib/auth";
+
+export default async function DashboardPage() {
+	const user = await getUser();
+
+	if (!user) {
+		redirect("/login");
+	}
+
+	return (
+		<div style={{ maxWidth: 600, margin: "40px auto", padding: "0 16px" }}>
+			<h1 style={{ fontSize: 24, marginBottom: 16 }}>ダッシュボード</h1>
+			<p>ログイン中: {user.email}</p>
+		</div>
+	);
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { signIn, signInWithGoogle, signUp } from "@/app/_actions/auth";
+
+export default function LoginPage() {
+	const router = useRouter();
+	const [mode, setMode] = useState<"login" | "signup">("login");
+	const [error, setError] = useState("");
+	const [loading, setLoading] = useState(false);
+
+	async function handleSubmit(formData: FormData) {
+		setError("");
+		setLoading(true);
+
+		const action = mode === "login" ? signIn : signUp;
+		const result = await action(formData);
+
+		if (result.success) {
+			router.push("/dashboard");
+		} else {
+			setError(result.error);
+		}
+		setLoading(false);
+	}
+
+	async function handleGoogleSignIn() {
+		setError("");
+		const result = await signInWithGoogle();
+		if (result.success) {
+			window.location.href = result.data.url;
+		} else {
+			setError(result.error);
+		}
+	}
+
+	return (
+		<div style={{ maxWidth: 400, margin: "80px auto", padding: "0 16px" }}>
+			<h1 style={{ fontSize: 24, marginBottom: 24 }}>KanjouAI</h1>
+
+			<div style={{ display: "flex", gap: 8, marginBottom: 24 }}>
+				<button
+					type="button"
+					onClick={() => {
+						setMode("login");
+						setError("");
+					}}
+					style={{ fontWeight: mode === "login" ? "bold" : "normal" }}
+				>
+					ログイン
+				</button>
+				<button
+					type="button"
+					onClick={() => {
+						setMode("signup");
+						setError("");
+					}}
+					style={{ fontWeight: mode === "signup" ? "bold" : "normal" }}
+				>
+					新規登録
+				</button>
+			</div>
+
+			<form action={handleSubmit}>
+				<div style={{ marginBottom: 12 }}>
+					<label htmlFor="email">メールアドレス</label>
+					<br />
+					<input
+						id="email"
+						name="email"
+						type="email"
+						required
+						style={{ width: "100%", padding: 8, marginTop: 4 }}
+					/>
+				</div>
+
+				<div style={{ marginBottom: 12 }}>
+					<label htmlFor="password">パスワード{mode === "signup" ? "（8文字以上）" : ""}</label>
+					<br />
+					<input
+						id="password"
+						name="password"
+						type="password"
+						required
+						minLength={mode === "signup" ? 8 : undefined}
+						style={{ width: "100%", padding: 8, marginTop: 4 }}
+					/>
+				</div>
+
+				{error && <p style={{ color: "red", marginBottom: 12 }}>{error}</p>}
+
+				<button
+					type="submit"
+					disabled={loading}
+					style={{ width: "100%", padding: 10, marginBottom: 12 }}
+				>
+					{loading ? "処理中..." : mode === "login" ? "ログイン" : "新規登録"}
+				</button>
+			</form>
+
+			<hr style={{ margin: "16px 0" }} />
+
+			<button type="button" onClick={handleGoogleSignIn} style={{ width: "100%", padding: 10 }}>
+				Googleでログイン
+			</button>
+		</div>
+	);
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -31,8 +31,8 @@ export async function updateSession(request: NextRequest) {
 	} = await supabase.auth.getUser();
 
 	// 未認証ユーザーをログインページにリダイレクト
-	// 公開ページ（/, /login, /signup）はスキップ
-	const publicPaths = ["/", "/login", "/signup"];
+	// 公開ページと認証コールバックはスキップ
+	const publicPaths = ["/", "/login", "/signup", "/auth/callback"];
 	const isPublicPath = publicPaths.some((path) => request.nextUrl.pathname === path);
 
 	if (!user && !isPublicPath) {


### PR DESCRIPTION
## Summary
- ログイン/新規登録切替画面を実装（最低限 UI、デザインは Phase 1 完了後に v0.dev で整備）
- Google OAuth コールバックルートを作成
- 認証後リダイレクト先の最低限ダッシュボードを作成
- ミドルウェアに `/auth/callback` を公開パスとして追加

## Changes
| ファイル | 概要 |
|---------|------|
| `app/login/page.tsx` | ログイン/新規登録切替画面（Client Component） |
| `app/auth/callback/route.ts` | OAuth コールバック（コード→セッション交換） |
| `app/dashboard/page.tsx` | 最低限ダッシュボード（Server Component、認証チェック付き） |
| `lib/supabase/middleware.ts` | `/auth/callback` を公開パスに追加 |

## Test plan
- [x] `npm run typecheck` — 型エラー 0件
- [x] `npm run lint` — Biome エラー 0件
- [x] `npm run test:unit` — 51テスト全通過
- [x] カバレッジ: 全体 91.83%（閾値 80% クリア）
- [ ] 手動確認: `/login` でログイン/新規登録フォーム表示
- [ ] 手動確認: Google OAuth フロー動作

## 機能詳細
- **ログイン画面**: メール/パスワードフォーム + Google OAuth ボタン、タブでログイン/新規登録切替
- **OAuth コールバック**: `code` パラメータをセッションに交換し `/dashboard` にリダイレクト
- **ダッシュボード**: `getUser()` で認証チェック、未認証は `/login` にリダイレクト

## PR Size
- 4 files changed, 142 insertions(+), 2 deletions(-)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)