### PR TITLE
feat: プロフィール設定画面 UI（Issue #8 後半）

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getProfile, updateProfile } from "@/app/_actions/profile";
+import { TAX_CATEGORIES } from "@/lib/utils/constants";
+
+export default function SettingsPage() {
+	const [displayName, setDisplayName] = useState("");
+	const [fiscalYearStart, setFiscalYearStart] = useState("1");
+	const [defaultTaxRate, setDefaultTaxRate] = useState("tax_10");
+	const [message, setMessage] = useState("");
+	const [error, setError] = useState("");
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		getProfile().then((result) => {
+			if (result.success) {
+				setDisplayName(result.data.display_name ?? "");
+				setFiscalYearStart(String(result.data.fiscal_year_start));
+				setDefaultTaxRate(result.data.default_tax_rate);
+			}
+			setLoading(false);
+		});
+	}, []);
+
+	async function handleSubmit(formData: FormData) {
+		setMessage("");
+		setError("");
+
+		const result = await updateProfile(formData);
+
+		if (result.success) {
+			setMessage("保存しました。");
+		} else {
+			setError(result.error);
+		}
+	}
+
+	if (loading) return <p style={{ margin: 40 }}>読み込み中...</p>;
+
+	return (
+		<div style={{ maxWidth: 400, margin: "40px auto", padding: "0 16px" }}>
+			<h1 style={{ fontSize: 24, marginBottom: 24 }}>設定</h1>
+
+			<form action={handleSubmit}>
+				<div style={{ marginBottom: 12 }}>
+					<label htmlFor="displayName">表示名</label>
+					<br />
+					<input
+						id="displayName"
+						name="displayName"
+						type="text"
+						value={displayName}
+						onChange={(e) => setDisplayName(e.target.value)}
+						maxLength={50}
+						style={{ width: "100%", padding: 8, marginTop: 4 }}
+					/>
+				</div>
+
+				<div style={{ marginBottom: 12 }}>
+					<label htmlFor="fiscalYearStart">会計年度開始月</label>
+					<br />
+					<select
+						id="fiscalYearStart"
+						name="fiscalYearStart"
+						value={fiscalYearStart}
+						onChange={(e) => setFiscalYearStart(e.target.value)}
+						style={{ width: "100%", padding: 8, marginTop: 4 }}
+					>
+						{Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
+							<option key={month} value={month}>
+								{month}月
+							</option>
+						))}
+					</select>
+				</div>
+
+				<div style={{ marginBottom: 12 }}>
+					<label htmlFor="defaultTaxRate">デフォルト税区分</label>
+					<br />
+					<select
+						id="defaultTaxRate"
+						name="defaultTaxRate"
+						value={defaultTaxRate}
+						onChange={(e) => setDefaultTaxRate(e.target.value)}
+						style={{ width: "100%", padding: 8, marginTop: 4 }}
+					>
+						{Object.entries(TAX_CATEGORIES).map(([key, { name }]) => (
+							<option key={key} value={key}>
+								{name}
+							</option>
+						))}
+					</select>
+				</div>
+
+				{message && <p style={{ color: "green", marginBottom: 12 }}>{message}</p>}
+				{error && <p style={{ color: "red", marginBottom: 12 }}>{error}</p>}
+
+				<button type="submit" style={{ width: "100%", padding: 10 }}>
+					保存
+				</button>
+			</form>
+		</div>
+	);
+}


### PR DESCRIPTION
## 概要
Issue #8（プロフィール設定）の後半PR。設定画面の最小限UIを追加。

PR #30 で作成済みの Server Actions（getProfile / updateProfile）を利用し、
表示名・会計年度開始月・デフォルト税区分を編集できるフォームを実装。

Closes #8

## 変更内容
- `app/settings/page.tsx`: プロフィール設定画面（Client Component）
  - useEffect で getProfile() を呼び出しプロフィールをロード
  - 表示名（テキスト入力、50文字制限）
  - 会計年度開始月（1-12月セレクト）
  - デフォルト税区分（TAX_CATEGORIES からセレクト）
  - updateProfile Server Action によるフォーム送信
  - 成功/エラーメッセージ表示

## テスト計画
- [x] Server Actions のユニットテスト（PR #30 で実装済み、8テスト通過）
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run test:unit` 全59テスト通過
- [ ] UI は Phase 1 完了後に v0.dev でデザイン改善予定

## サイズ
- 105行追加 / 1ファイル変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)