### PR TITLE
docs: Claude Code リファレンスドキュメント追加

### DIFF
--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -1,0 +1,248 @@
+# Architecture Guide
+
+## File Structure
+
+```
+app/
+├── layout.tsx                    # Root layout (Server Component)
+├── page.tsx                      # Landing page
+├── login/
+│   └── page.tsx                  # ログイン/サインアップ画面 (Client Component)
+├── dashboard/
+│   └── page.tsx                  # ダッシュボード (Server Component)
+├── settings/
+│   └── page.tsx                  # プロフィール設定 (Client Component)
+├── auth/
+│   └── callback/
+│       └── route.ts              # OAuth コールバック (Route Handler)
+└── _actions/
+    ├── auth.ts                   # 認証 Server Actions (signIn, signUp, signInWithGoogle, signOut)
+    ├── profile.ts                # プロフィール Server Actions (getProfile, updateProfile)
+    └── __tests__/
+        ├── auth.test.ts          # 認証テスト (9 cases)
+        └── profile.test.ts       # プロフィールテスト (8 cases)
+
+lib/
+├── api/
+│   └── error.ts                  # handleApiError() + ApiError クラス + エラーコード定数
+├── auth.ts                       # getUser(), requireAuth()
+├── auth/
+│   └── __tests__/
+│       └── auth.test.ts          # 認証ユーティリティテスト (7 cases)
+├── csv/
+│   └── parsers.ts                # CSV パーサー (Wise, Revolut, generic)
+├── supabase/
+│   ├── server.ts                 # createServerClient (Server Component / Server Action 用)
+│   ├── client.ts                 # createBrowserClient (Client Component 用)
+│   └── middleware.ts             # セッション更新 + 認証リダイレクト
+├── types/
+│   ├── api.ts                    # ApiResponse<T> 型定義
+│   └── supabase.ts               # Supabase 自動生成型 (npx supabase gen types)
+├── validators/
+│   ├── auth.ts                   # loginSchema, signupSchema
+│   ├── profile.ts                # updateProfileSchema
+│   ├── transaction.ts            # createTransactionSchema, aiClassifyRequestSchema
+│   └── __tests__/
+│       └── transaction.test.ts   # バリデーションテスト (12 cases)
+└── utils/
+    └── constants.ts              # 勘定科目, 税区分, アップロード/レート制限
+
+middleware.ts                     # Next.js Middleware エントリポイント → updateSession()
+vitest.config.ts                  # Vitest 設定 (jsdom, v8 coverage, 80% threshold)
+```
+
+## Server Actions パターン
+
+### 基本構造
+
+`app/_actions/auth.ts` をベースとした標準パターン:
+
+```typescript
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { handleApiError } from "@/lib/api/error";
+import { createClient } from "@/lib/supabase/server";
+import type { ApiResponse } from "@/lib/types/api";
+import { someSchema } from "@/lib/validators/some-domain";
+
+export async function someAction(formData: FormData): Promise<ApiResponse<T>> {
+  try {
+    // 1. 認証チェック（必要な場合）
+    const authResult = await requireAuth();
+    if (!authResult.success) return authResult;
+
+    // 2. Zod バリデーション
+    const parsed = someSchema.safeParse({
+      field: formData.get("field"),
+    });
+    if (!parsed.success) {
+      return {
+        success: false,
+        error: "ユーザー向けエラーメッセージ",
+        code: "VALIDATION_ERROR",
+      };
+    }
+
+    // 3. Supabase 操作
+    const supabase = await createClient();
+    const { error } = await supabase.from("table").insert({...});
+    if (error) return handleApiError(error);
+
+    // 4. キャッシュ無効化 + 成功レスポンス
+    revalidatePath("/path");
+    return { success: true, data: null };
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+```
+
+### ルール
+
+- 必ず `"use server"` ディレクティブを付ける
+- 戻り値は必ず `ApiResponse<T>`
+- `try-catch` で囲み、catch では `handleApiError(error)` を返す
+- Zod の `safeParse` を使い、`!parsed.success` で早期リターン
+- Zod のエラー詳細はクライアントに返さない（固定メッセージを使う）
+- データ変更後は `revalidatePath()` を呼ぶ
+- 認証が必要なアクションは冒頭で `requireAuth()` を呼ぶ
+
+### 認証ユーティリティ
+
+```typescript
+// lib/auth.ts
+import { createClient } from "@/lib/supabase/server";
+
+// ユーザー取得（null 許容）— Server Component での分岐用
+export async function getUser(): Promise<User | null>
+
+// 認証必須（ApiResponse 形式）— Server Action でのガード用
+export async function requireAuth(): Promise<ApiResponse<User>>
+```
+
+## Database Patterns
+
+### テーブル構成
+
+| テーブル | 用途 | RLS |
+|---------|------|-----|
+| profiles | ユーザープロフィール（auth.users と 1:1） | `auth.uid() = id` |
+| account_categories | 勘定科目マスタ（システム + ユーザーカスタム） | `user_id IS NULL OR auth.uid() = user_id` |
+| transactions | 仕訳データ | `auth.uid() = user_id` |
+| import_logs | CSV インポート履歴 | `auth.uid() = user_id` |
+| csv_mappings | CSV カラムマッピング設定 | `auth.uid() = user_id` |
+
+### RLS ポリシーパターン
+
+全テーブルで `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` を有効化。
+
+```sql
+-- 基本パターン: 自分のデータのみアクセス可能
+CREATE POLICY "table_select_own" ON table FOR SELECT
+  USING (auth.uid() = user_id AND deleted_at IS NULL);
+CREATE POLICY "table_insert_own" ON table FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "table_update_own" ON table FOR UPDATE
+  USING (auth.uid() = user_id AND deleted_at IS NULL);
+```
+
+### Soft Delete
+
+- `deleted_at TIMESTAMPTZ` カラムで論理削除
+- SELECT ポリシーに `deleted_at IS NULL` 条件を含める
+- 物理削除は行わない
+
+### 金額
+
+- `INT` 型（円単位、小数を避ける）
+- `CHECK (amount > 0)` 制約
+- 外貨の場合は `original_amount NUMERIC` + `exchange_rate NUMERIC` を別途保持
+
+### 自動トリガー
+
+- `update_updated_at()`: UPDATE 時に `updated_at` を自動更新
+- `handle_new_user()`: `auth.users` への INSERT 時に `profiles` を自動作成（`SECURITY DEFINER`）
+
+## Data Flow
+
+### Server Component → Server Action → Supabase
+
+```
+[Client Component]
+  │ form action={serverAction}  or  onClick → serverAction(formData)
+  ▼
+[Server Action] (app/_actions/*.ts)
+  │ 1. requireAuth() — 認証チェック
+  │ 2. zodSchema.safeParse() — 入力バリデーション
+  │ 3. supabase.from("table").insert/update/select()
+  │ 4. revalidatePath() — キャッシュ無効化
+  │ 5. return ApiResponse<T>
+  ▼
+[Client Component]
+  │ result.success ? 成功表示 : エラー表示
+```
+
+### Server Component でのデータ取得
+
+```
+[Server Component] (app/dashboard/page.tsx)
+  │ const user = await getUser()  — Cookie ベースで認証
+  │ if (!user) redirect("/login")
+  │ const supabase = await createClient()
+  │ const { data } = await supabase.from("table").select()
+  ▼
+[JSX レンダリング]
+```
+
+### OAuth フロー
+
+```
+[Login Page] signInWithGoogle()
+  → Supabase OAuth URL 取得
+  → window.location.href でリダイレクト
+  → Google 認証画面
+  → /auth/callback?code=xxx
+  → [Route Handler] exchangeCodeForSession(code)
+  → redirect("/dashboard")
+```
+
+## Error Handling Flow
+
+### ApiResponse<T> 型
+
+```typescript
+type ApiResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; code?: string };
+```
+
+### handleApiError() の分岐
+
+```
+[error]
+  ├── ApiError           → { error: error.message, code: error.code }
+  ├── ZodError (issues)  → { error: "入力内容を確認してください。", code: "VALIDATION_ERROR" }
+  ├── Supabase 42501     → { error: "この操作を行う権限がありません。", code: "FORBIDDEN" }
+  ├── Supabase 23505     → { error: "この項目は既に存在します。", code: "CONFLICT" }
+  ├── Supabase その他     → { error: "データベースエラーが発生しました。", code: "INTERNAL_ERROR" }
+  └── unknown            → { error: "予期しないエラーが発生しました。", code: "INTERNAL_ERROR" }
+```
+
+### エラーコード一覧
+
+```typescript
+// lib/api/error.ts
+const API_ERROR_CODES = {
+  UNAUTHORIZED,       // 未認証
+  FORBIDDEN,          // 権限なし (RLS 違反)
+  NOT_FOUND,          // リソース未検出
+  VALIDATION_ERROR,   // 入力バリデーション失敗
+  CONFLICT,           // 重複 (UNIQUE 制約違反)
+  RATE_LIMIT,         // レート制限超過
+  AI_ERROR,           // Claude API エラー
+  CSV_PARSE_ERROR,    // CSV パースエラー
+  EXPORT_ERROR,       // エクスポートエラー
+  INTERNAL_ERROR,     // その他の内部エラー
+};
+```

--- a/.claude/security.md
+++ b/.claude/security.md
@@ -1,0 +1,230 @@
+# Security Guide
+
+## handleApiError による情報漏洩防止
+
+`lib/api/error.ts` の `handleApiError()` が全エラーを一元処理し、内部情報の漏洩を防ぐ。
+
+### 原則
+
+- Zod バリデーションエラーの詳細（`issues` 配列）をクライアントに返さない
+- Supabase のエラーメッセージ（テーブル名、カラム名、SQL ステート）を露出しない
+- スタックトレースをレスポンスに含めない
+- `console.error` でサーバーログに記録するが、ユーザー PII（メール等）は含めない
+
+### 実装パターン
+
+```typescript
+// ✅ 正しい: 固定メッセージを返す
+if (!parsed.success) {
+  return {
+    success: false,
+    error: "メールアドレスとパスワードを正しく入力してください。",
+    code: "VALIDATION_ERROR",
+  };
+}
+
+// ❌ 間違い: Zod のエラー詳細をそのまま返す
+if (!parsed.success) {
+  return {
+    success: false,
+    error: parsed.error.issues.map(i => i.message).join(", "),
+    code: "VALIDATION_ERROR",
+  };
+}
+```
+
+### Supabase エラーの変換
+
+```typescript
+// handleApiError 内部での処理:
+// PostgreSQL 42501 (RLS 違反) → "この操作を行う権限がありません。"
+// PostgreSQL 23505 (UNIQUE 違反) → "この項目は既に存在します。"
+// その他の DB エラー → "データベースエラーが発生しました。"
+// 不明なエラー → "予期しないエラーが発生しました。"
+```
+
+### テストでの検証
+
+テストでは内部メッセージが漏れていないことを必ず確認する:
+
+```typescript
+// tests/unit/lib/__tests__/api-error.test.ts より
+expect(result.error).not.toContain("row-level security");
+expect(result.error).not.toContain("secret");
+expect(result.error).not.toContain("Invalid login credentials");
+```
+
+## Supabase Auth + Middleware のセッション管理
+
+### アーキテクチャ
+
+```
+[Browser] → [Next.js Middleware] → [Server Component / Server Action]
+              │
+              ├── updateSession(): セッション Cookie を更新
+              ├── 未認証 + 非公開パス → /login にリダイレクト
+              └── 公開パス: /, /login, /signup, /auth/callback
+```
+
+### Middleware (middleware.ts → lib/supabase/middleware.ts)
+
+```typescript
+// matcher で静的アセットを除外
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+};
+```
+
+- `updateSession()` が毎リクエストで Supabase セッションを更新
+- Cookie ベースのセッション管理（`@supabase/ssr` の `createServerClient`）
+- Cookie の getAll/setAll を Request/Response オブジェクト経由で処理
+
+### 認証チェックの使い分け
+
+| 関数 | 用途 | 戻り値 |
+|------|------|--------|
+| `getUser()` | Server Component での分岐 | `User \| null` |
+| `requireAuth()` | Server Action でのガード | `ApiResponse<User>` |
+
+```typescript
+// Server Component
+const user = await getUser();
+if (!user) redirect("/login");
+
+// Server Action
+const authResult = await requireAuth();
+if (!authResult.success) return authResult;  // 早期リターンで UNAUTHORIZED を返す
+const userId = authResult.data.id;
+```
+
+### Supabase Client の使い分け
+
+| クライアント | ファイル | 用途 |
+|------------|---------|------|
+| `createClient()` (server) | `lib/supabase/server.ts` | Server Component, Server Action |
+| `createClient()` (client) | `lib/supabase/client.ts` | Client Component（極力使わない） |
+
+- Server 側は `cookies()` から Cookie を取得
+- Client Component から直接 Supabase クエリは原則禁止（Server Action 経由）
+
+## RLS ポリシー
+
+### 全テーブル共通ルール
+
+1. `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` を必ず有効化
+2. `auth.uid() = user_id` で自分のデータのみアクセス可能
+3. SELECT/UPDATE で `deleted_at IS NULL` 条件を含める（Soft Delete 対応）
+4. INSERT では `WITH CHECK (auth.uid() = user_id)` で所有者チェック
+
+### テーブル別ポリシー
+
+**profiles**: `auth.uid() = id`（profiles.id = auth.users.id）
+- SELECT: own + not deleted
+- INSERT: own
+- UPDATE: own + not deleted
+- DELETE: なし（Soft Delete のみ）
+
+**account_categories**: システムプリセット（`user_id IS NULL`）は全員参照可
+- SELECT: `user_id IS NULL OR auth.uid() = user_id`
+- INSERT/UPDATE/DELETE: `auth.uid() = user_id`
+
+**transactions, import_logs, csv_mappings**: 標準パターン
+- SELECT: `auth.uid() = user_id [AND deleted_at IS NULL]`
+- INSERT: `auth.uid() = user_id`
+- UPDATE: `auth.uid() = user_id [AND deleted_at IS NULL]`
+- DELETE: `auth.uid() = user_id`
+
+### RLS 違反のハンドリング
+
+Supabase が返す PostgreSQL エラーコード `42501` を `handleApiError()` が捕捉し、
+`FORBIDDEN` コードと汎用メッセージに変換する。RLS ポリシー名やテーブル名は露出しない。
+
+## 環境変数管理
+
+### NEXT_PUBLIC_ の使い分け
+
+| 変数 | プレフィックス | 理由 |
+|------|--------------|------|
+| `NEXT_PUBLIC_SUPABASE_URL` | `NEXT_PUBLIC_` | クライアント/サーバー両方で使用（公開情報） |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | `NEXT_PUBLIC_` | クライアント/サーバー両方で使用（公開キー、RLS で保護） |
+| `SUPABASE_SERVICE_ROLE_KEY` | なし | サーバーのみ（RLS バイパス権限、絶対に露出させない） |
+| `ANTHROPIC_API_KEY` | なし | サーバーのみ（Claude API 秘密鍵） |
+
+### 注意点
+
+- `NEXT_PUBLIC_` 付きの変数はブラウザに配信される
+- Anon Key は公開前提だが、RLS で保護されているため安全
+- Service Role Key はサーバー専用（Admin 操作用）。Client Component や公開コードに含めない
+- 環境変数の Non-null assertion には `biome-ignore` コメントを付与
+
+## 脆弱性パターンと対策
+
+### IDOR (Insecure Direct Object Reference)
+
+**リスク**: 他人の `user_id` を指定してデータにアクセス
+
+**対策**: RLS が DB レベルで防御。アプリケーションコードでも `requireAuth()` で取得した `user_id` のみを使用。
+
+```typescript
+// ✅ 正しい: 認証済みユーザーの ID を使う
+const authResult = await requireAuth();
+const { data } = await supabase
+  .from("transactions")
+  .select()
+  .eq("user_id", authResult.data.id);  // RLS + アプリケーションレベルで二重防御
+
+// ❌ 間違い: リクエストから受け取った ID をそのまま使う
+const userId = formData.get("userId");
+const { data } = await supabase
+  .from("transactions")
+  .select()
+  .eq("user_id", userId);  // IDOR 脆弱性
+```
+
+### Mass Assignment
+
+**リスク**: FormData に意図しないフィールドが含まれ、予期しないカラムが更新される
+
+**対策**: Zod スキーマで許可するフィールドを明示的に定義。`safeParse()` が未定義フィールドを除去。
+
+```typescript
+// Zod スキーマが許可するフィールドのみ通す
+const parsed = updateProfileSchema.safeParse({
+  displayName: formData.get("displayName") || undefined,
+  fiscalYearStart: Number(formData.get("fiscalYearStart")),
+  defaultTaxRate: formData.get("defaultTaxRate"),
+});
+
+// parsed.data には定義済みフィールドのみ含まれる
+await supabase.from("profiles").update({
+  display_name: parsed.data.displayName ?? null,
+  fiscal_year_start: parsed.data.fiscalYearStart,
+  default_tax_rate: parsed.data.defaultTaxRate,
+  // ↑ is_admin や role などの不正フィールドは含まれない
+});
+```
+
+### XSS (Cross-Site Scripting)
+
+**対策**: React がデフォルトで JSX 出力をエスケープ。`dangerouslySetInnerHTML` は使用しない。
+
+### SQL Injection
+
+**対策**: Supabase Client SDK がパラメータ化クエリを使用。生 SQL は使わない。
+
+### CSRF (Cross-Site Request Forgery)
+
+**対策**: Next.js Server Actions は POST + Origin ヘッダー検証を組み込み済み。
+
+### ログ出力ルール
+
+```typescript
+// ✅ 許可
+console.error("[handleApiError] Unexpected error:", error);
+console.warn("Rate limit approaching for action:", actionName);
+
+// ❌ 禁止
+console.log("User email:", user.email);   // PII 漏洩
+console.log("Processing...");             // 本番 console.log 禁止
+console.error("Error for user:", email);  // PII をログに含めない
+```

--- a/.claude/testing.md
+++ b/.claude/testing.md
@@ -1,0 +1,268 @@
+# Testing Guide
+
+## TDD Red-Green-Refactor ワークフロー
+
+全新機能は `/tdd` コマンドで以下のサイクルに従う:
+
+```
+1. 🔴 RED:      失敗するテストを書く → npm run test:unit で FAIL を確認
+2. 🟢 GREEN:    テストを通す最小限の実装 → npm run test:unit で PASS を確認
+3. 🔵 REFACTOR: テストが通る状態を維持しながらリファクタ → npm run test:unit で PASS を確認
+```
+
+### ルール
+
+- テストを書く前に実装コードを書かない
+- RED でテストが失敗することを確認してから GREEN に進む
+- GREEN では最小限の実装のみ（きれいなコードは REFACTOR で）
+- 1サイクルの粒度は 1メソッド / 1ユースケース単位
+- テストに書いていない機能を追加しない
+
+## テストファイル配置
+
+```
+{対象ファイルのパス}/__tests__/{ファイル名}.test.ts
+```
+
+| 対象 | テストファイル |
+|------|-------------|
+| `app/_actions/auth.ts` | `app/_actions/__tests__/auth.test.ts` |
+| `app/_actions/profile.ts` | `app/_actions/__tests__/profile.test.ts` |
+| `lib/auth.ts` | `lib/auth/__tests__/auth.test.ts` |
+| `lib/api/error.ts` | `tests/unit/lib/__tests__/api-error.test.ts` |
+| `lib/csv/parsers.ts` | `tests/unit/lib/__tests__/csv-parsers.test.ts` |
+| `lib/validators/transaction.ts` | `lib/validators/__tests__/transaction.test.ts` |
+
+## モックパターン
+
+### Supabase Client モック
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock は import より前に巻き上げられる
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "@/lib/supabase/server";
+const mockCreateClient = vi.mocked(createClient);
+```
+
+#### チェーン API のモック（SELECT）
+
+```typescript
+// supabase.from("table").select("cols").eq("id", value).single()
+const mockSingle = vi.fn().mockResolvedValue({
+  data: { display_name: "テスト", fiscal_year_start: 4, default_tax_rate: "tax_10" },
+  error: null,
+});
+mockCreateClient.mockResolvedValue({
+  from: vi.fn().mockReturnValue({
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({ single: mockSingle }),
+    }),
+  }),
+} as unknown as Awaited<ReturnType<typeof createClient>>);
+```
+
+#### チェーン API のモック（UPDATE）
+
+```typescript
+// supabase.from("table").update({...}).eq("id", value)
+const mockEq = vi.fn().mockResolvedValue({ error: null });
+mockCreateClient.mockResolvedValue({
+  from: vi.fn().mockReturnValue({
+    update: vi.fn().mockReturnValue({ eq: mockEq }),
+  }),
+} as unknown as Awaited<ReturnType<typeof createClient>>);
+```
+
+#### Auth API のモック
+
+```typescript
+// supabase.auth.signInWithPassword / signUp / signOut / signInWithOAuth
+const mockSignInWithPassword = vi.fn();
+const mockSignUp = vi.fn();
+const mockSignOut = vi.fn();
+const mockSignInWithOAuth = vi.fn();
+
+mockCreateClient.mockResolvedValue({
+  auth: {
+    signInWithPassword: mockSignInWithPassword,
+    signUp: mockSignUp,
+    signOut: mockSignOut,
+    signInWithOAuth: mockSignInWithOAuth,
+  },
+} as unknown as Awaited<ReturnType<typeof createClient>>);
+```
+
+### Auth モック（requireAuth）
+
+```typescript
+vi.mock("@/lib/auth", () => ({
+  requireAuth: vi.fn(),
+}));
+
+import { requireAuth } from "@/lib/auth";
+const mockRequireAuth = vi.mocked(requireAuth);
+
+// 認証済み
+mockRequireAuth.mockResolvedValue({
+  success: true,
+  data: { id: "user-123" } as never,
+});
+
+// 未認証
+mockRequireAuth.mockResolvedValue({
+  success: false,
+  error: "ログインが必要です。",
+  code: "UNAUTHORIZED",
+});
+```
+
+### next/cache モック
+
+```typescript
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+```
+
+## AAA パターン（Arrange-Act-Assert）
+
+```typescript
+it("正常にプロフィールを更新できる", async () => {
+  // Arrange: モックとテストデータを準備
+  mockRequireAuth.mockResolvedValue({
+    success: true,
+    data: { id: "user-123" } as never,
+  });
+  const mockEq = vi.fn().mockResolvedValue({ error: null });
+  mockCreateClient.mockResolvedValue({
+    from: vi.fn().mockReturnValue({
+      update: vi.fn().mockReturnValue({ eq: mockEq }),
+    }),
+  } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+  // Act: テスト対象を実行
+  const result = await updateProfile(
+    createFormData({
+      displayName: "テストユーザー",
+      fiscalYearStart: "4",
+      defaultTaxRate: "tax_10",
+    }),
+  );
+
+  // Assert: 結果を検証
+  expect(result.success).toBe(true);
+});
+```
+
+## FormData ヘルパー
+
+Server Action のテストでは `FormData` を組み立てるヘルパーを使う:
+
+```typescript
+function createFormData(data: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(data)) {
+    fd.set(key, value);
+  }
+  return fd;
+}
+```
+
+## テストケースの網羅パターン
+
+### Server Action テスト
+
+1. **正常系**: 有効な入力で成功
+2. **バリデーションエラー**: 不正な入力で `VALIDATION_ERROR`
+3. **未認証**: `requireAuth()` が失敗 → `UNAUTHORIZED`
+4. **DB エラー**: Supabase がエラーを返す（RLS 違反, 重複等）
+5. **エラー情報非漏洩**: 内部メッセージがレスポンスに含まれないこと
+
+```typescript
+// エラー情報非漏洩の検証例
+it("DB更新エラー時にエラーを返す", async () => {
+  const mockEq = vi.fn().mockResolvedValue({
+    error: { code: "42501", message: "RLS violation" },
+  });
+  // ...
+
+  const result = await updateProfile(createFormData({...}));
+
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error).not.toContain("RLS violation");  // 内部情報が漏れない
+  }
+});
+```
+
+### バリデーションテスト
+
+1. **正常な入力**: 全フィールド有効
+2. **境界値**: min/max の境界（e.g., 会計年度 0, 1, 12, 13）
+3. **型変換**: 文字列→数値、トリム処理
+4. **オプショナル**: 省略可能フィールドの未指定
+
+## カバレッジ要件
+
+### 閾値（vitest.config.ts）
+
+```
+statements: 80%
+branches:   75%
+functions:  80%
+lines:      80%
+```
+
+### カバレッジ対象
+
+```
+include: lib/**/*.ts, lib/**/*.tsx, app/**/*.ts, app/**/*.tsx
+```
+
+### カバレッジ除外
+
+```
+exclude:
+  - lib/types/**           # 型定義（ロジックなし）
+  - lib/**/*.d.ts          # 型宣言ファイル
+  - lib/utils/constants.ts # 定数定義（ロジックなし）
+  - lib/supabase/**        # Supabase クライアント初期化（環境依存）
+  - app/**/page.tsx        # ページコンポーネント（UI、E2E でカバー）
+  - app/**/layout.tsx      # レイアウト（UI、E2E でカバー）
+  - app/**/route.ts        # Route Handler（統合テストでカバー）
+```
+
+### コマンド
+
+```bash
+npm run test:unit            # テスト実行
+npm run test:unit:coverage   # カバレッジ付きで実行
+```
+
+## beforeEach パターン
+
+```typescript
+beforeEach(() => {
+  vi.clearAllMocks();  // 全モックをリセット（各テストの独立性を保証）
+});
+```
+
+## Type Narrowing パターン
+
+`ApiResponse<T>` の型ガードでテスト:
+
+```typescript
+const result = await someAction(formData);
+
+expect(result.success).toBe(false);
+if (!result.success) {
+  // TypeScript が error と code の存在を認識
+  expect(result.code).toBe("VALIDATION_ERROR");
+  expect(result.error).toBe("...");
+}
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@
 
 ## Architecture Patterns
 
+詳細は `.claude/architecture.md` を参照してください。
+
 ### Server Actions
 
 - **配置**: `app/_actions/{domain}.ts`
@@ -48,6 +50,8 @@
 
 ## Security
 
+詳細は `.claude/security.md` を参照してください。
+
 ### エラーハンドリング
 
 - ❌ エラーレスポンスに `details`, `stack` を含めない
@@ -64,6 +68,8 @@
 - **認証チェック**: `lib/auth.ts` の `getUser()`, `requireAuth()` を使用
 
 ## Testing（TDD必須）
+
+詳細は `.claude/testing.md` を参照してください。
 
 新機能の実装は **必ず Red-Green-Refactor サイクル** に従うこと。
 
@@ -140,7 +146,9 @@ const results = await classifyTransactions(transactions);
 
 ## Task Guidelines
 
-- コード例: `.claude/examples.md` を参照
+- 機能追加時: `.claude/architecture.md` を参照
+- テスト作成時: `.claude/testing.md` を参照
+- セキュリティ作業: `.claude/security.md` を参照
 - タスクチェックリスト: `.claude/task-checklists.md` を参照
 
 ## Best Practices


### PR DESCRIPTION
## 概要
Phase 1 実装完了に基づき、実コードからリファレンスドキュメントを作成。
Claude Code がプロジェクトのパターンを正確に理解・再現するための基盤資料。

## 変更内容
- `.claude/architecture.md`: ファイル構造、Server Actions パターン、DB パターン（RLS/Soft Delete）、データフロー図、エラーハンドリングフロー
- `.claude/security.md`: handleApiError による情報漏洩防止、Supabase Auth + Middleware セッション管理、RLS ポリシー詳細、環境変数管理、IDOR/Mass Assignment 等の脆弱性パターンと対策
- `.claude/testing.md`: TDD Red-Green-Refactor ワークフロー、Supabase/Auth モックパターン（実テストコードベース）、AAA パターン、カバレッジ要件
- `CLAUDE.md`: 各セクションから詳細ドキュメントへの参照リンク追加

## テスト計画
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run test:unit` 全59テスト通過
- [x] ドキュメントのみの変更（コード変更なし）
- [x] `.md` ファイルは PR サイズチェック除外対象

🤖 Generated with [Claude Code](https://claude.com/claude-code)