### PR TITLE
feat: 取引一覧ページ（フィルタ + ソート + ページネーション）（Issue #10）

### DIFF
--- a/app/(app)/transactions/page.tsx
+++ b/app/(app)/transactions/page.tsx
@@ -1,0 +1,129 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getTransactions } from "@/app/_actions/transaction-actions";
+import { Badge } from "@/components/ui/badge";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { getUser } from "@/lib/auth";
+import { ACCOUNT_CATEGORIES } from "@/lib/utils/constants";
+
+interface PageProps {
+	searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function accountName(code: string): string {
+	const account = ACCOUNT_CATEGORIES[code as keyof typeof ACCOUNT_CATEGORIES];
+	return account?.name ?? code;
+}
+
+function buildPageHref(current: Record<string, string | undefined>, page: number): string {
+	const params = new URLSearchParams();
+	for (const [key, value] of Object.entries(current)) {
+		if (value && key !== "page") params.set(key, value);
+	}
+	params.set("page", String(page));
+	return `?${params.toString()}`;
+}
+
+export default async function TransactionsPage({ searchParams }: PageProps) {
+	const user = await getUser();
+	if (!user) redirect("/login");
+
+	const raw = await searchParams;
+	const params: Record<string, string | undefined> = {};
+	for (const [key, value] of Object.entries(raw)) {
+		params[key] = Array.isArray(value) ? value[0] : value;
+	}
+
+	const result = await getTransactions(params);
+
+	if (!result.success) {
+		return (
+			<div className="flex flex-col gap-6 p-4 md:p-6">
+				<h1 className="text-xl font-bold tracking-tight">取引一覧</h1>
+				<p className="text-sm text-destructive">{result.error}</p>
+			</div>
+		);
+	}
+
+	const { transactions, total, page, perPage } = result.data;
+	const totalPages = Math.ceil(total / perPage);
+
+	return (
+		<div className="flex flex-col gap-6 p-4 md:p-6">
+			<div>
+				<h1 className="text-xl font-bold tracking-tight">取引一覧</h1>
+				<p className="text-sm text-muted-foreground">{total}件の取引</p>
+			</div>
+
+			{transactions.length === 0 ? (
+				<div className="rounded-lg border bg-card p-10 text-center text-card-foreground">
+					<p className="text-sm text-muted-foreground">取引がありません。</p>
+				</div>
+			) : (
+				<div className="rounded-lg border">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>日付</TableHead>
+								<TableHead>摘要</TableHead>
+								<TableHead className="text-right">金額</TableHead>
+								<TableHead>借方</TableHead>
+								<TableHead>貸方</TableHead>
+								<TableHead>状態</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{transactions.map((tx) => (
+								<TableRow key={tx.id}>
+									<TableCell className="whitespace-nowrap">{tx.transaction_date}</TableCell>
+									<TableCell>{tx.description}</TableCell>
+									<TableCell className="text-right whitespace-nowrap">
+										{tx.amount.toLocaleString()}円
+									</TableCell>
+									<TableCell>{accountName(tx.debit_account)}</TableCell>
+									<TableCell>{accountName(tx.credit_account)}</TableCell>
+									<TableCell>
+										<Badge variant={tx.is_confirmed ? "default" : "secondary"}>
+											{tx.is_confirmed ? "確認済" : "未確認"}
+										</Badge>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</div>
+			)}
+
+			{totalPages > 1 && (
+				<nav className="flex items-center justify-center gap-2" aria-label="ページネーション">
+					{page > 1 && (
+						<Link
+							href={buildPageHref(params, page - 1)}
+							className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+						>
+							前へ
+						</Link>
+					)}
+					<span className="text-sm text-muted-foreground">
+						{page} / {totalPages}
+					</span>
+					{page < totalPages && (
+						<Link
+							href={buildPageHref(params, page + 1)}
+							className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+						>
+							次へ
+						</Link>
+					)}
+				</nav>
+			)}
+		</div>
+	);
+}

--- a/app/_actions/__tests__/transaction-actions.test.ts
+++ b/app/_actions/__tests__/transaction-actions.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+	requireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+	createClient: vi.fn(),
+}));
+
+import { getTransactions } from "@/app/_actions/transaction-actions";
+import { requireAuth } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+
+const mockRequireAuth = vi.mocked(requireAuth);
+const mockCreateClient = vi.mocked(createClient);
+
+interface ChainMockResult {
+	data: unknown[] | null;
+	count: number | null;
+	error: { code: string; message: string } | null;
+}
+
+function createChainMock(result: ChainMockResult) {
+	const mock: Record<string, ReturnType<typeof vi.fn>> = {};
+	for (const method of ["select", "gte", "lte", "eq", "or", "order"]) {
+		mock[method] = vi.fn().mockReturnValue(mock);
+	}
+	mock.range = vi.fn().mockResolvedValue(result);
+	const mockFrom = vi.fn().mockReturnValue(mock);
+
+	mockCreateClient.mockResolvedValue({
+		from: mockFrom,
+	} as unknown as Awaited<ReturnType<typeof createClient>>);
+
+	return { mock, mockFrom };
+}
+
+function mockAuthSuccess() {
+	mockRequireAuth.mockResolvedValue({
+		success: true,
+		data: { id: "user-123" } as never,
+	});
+}
+
+const sampleTransaction = {
+	id: "txn-1",
+	user_id: "user-123",
+	transaction_date: "2026-01-15",
+	description: "テスト取引",
+	amount: 1000,
+	debit_account: "EXP001",
+	credit_account: "AST001",
+	tax_category: "tax_10",
+	ai_confidence: null,
+	ai_suggested: false,
+	is_confirmed: false,
+	memo: null,
+	original_amount: null,
+	original_currency: null,
+	exchange_rate: null,
+	fees: null,
+	source: "manual",
+	import_log_id: null,
+	created_at: "2026-01-15T00:00:00Z",
+	updated_at: "2026-01-15T00:00:00Z",
+	deleted_at: null,
+};
+
+describe("getTransactions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("未認証でUNAUTHORIZEDエラーを返す", async () => {
+		mockRequireAuth.mockResolvedValue({
+			success: false,
+			error: "ログインが必要です。",
+			code: "UNAUTHORIZED",
+		});
+
+		const result = await getTransactions({});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("UNAUTHORIZED");
+		}
+	});
+
+	it("デフォルトパラメータで取引一覧を取得できる", async () => {
+		mockAuthSuccess();
+		const { mock } = createChainMock({
+			data: [sampleTransaction],
+			count: 1,
+			error: null,
+		});
+
+		const result = await getTransactions({});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.transactions).toHaveLength(1);
+			expect(result.data.total).toBe(1);
+			expect(result.data.page).toBe(1);
+			expect(result.data.perPage).toBe(20);
+		}
+		expect(mock.select).toHaveBeenCalledWith("*", { count: "exact" });
+		expect(mock.order).toHaveBeenCalledWith("transaction_date", {
+			ascending: false,
+		});
+		expect(mock.range).toHaveBeenCalledWith(0, 19);
+	});
+
+	it("取引が0件の場合に空配列を返す", async () => {
+		mockAuthSuccess();
+		createChainMock({ data: [], count: 0, error: null });
+
+		const result = await getTransactions({});
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.transactions).toHaveLength(0);
+			expect(result.data.total).toBe(0);
+		}
+	});
+
+	it("日付範囲でフィルタできる", async () => {
+		mockAuthSuccess();
+		const { mock } = createChainMock({ data: [], count: 0, error: null });
+
+		await getTransactions({
+			startDate: "2026-01-01",
+			endDate: "2026-03-31",
+		});
+
+		expect(mock.gte).toHaveBeenCalledWith("transaction_date", "2026-01-01");
+		expect(mock.lte).toHaveBeenCalledWith("transaction_date", "2026-03-31");
+	});
+
+	it("確認済みフィルタで絞り込める", async () => {
+		mockAuthSuccess();
+		const { mock } = createChainMock({ data: [], count: 0, error: null });
+
+		await getTransactions({ isConfirmed: "true" });
+
+		expect(mock.eq).toHaveBeenCalledWith("is_confirmed", true);
+	});
+
+	it("未確認フィルタで絞り込める", async () => {
+		mockAuthSuccess();
+		const { mock } = createChainMock({ data: [], count: 0, error: null });
+
+		await getTransactions({ isConfirmed: "false" });
+
+		expect(mock.eq).toHaveBeenCalledWith("is_confirmed", false);
+	});
+
+	it("勘定科目でフィルタできる", async () => {
+		mockAuthSuccess();
+		const { mock } = createChainMock({ data: [], count: 0, error: null });
+
+		await getTransactions({ accountCategory: "EXP001" });
+
+		expect(mock.or).toHaveBeenCalledWith("debit_account.eq.EXP001,credit_account.eq.EXP001");
+	});
+
+	it("ページネーションが正しく動作する", async () => {
+		mockAuthSuccess();
+		const { mock } = createChainMock({ data: [], count: 50, error: null });
+
+		const result = await getTransactions({ page: "3", perPage: "10" });
+
+		expect(mock.range).toHaveBeenCalledWith(20, 29);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.page).toBe(3);
+			expect(result.data.perPage).toBe(10);
+			expect(result.data.total).toBe(50);
+		}
+	});
+
+	it("無効なページ番号でバリデーションエラーを返す", async () => {
+		mockAuthSuccess();
+
+		const result = await getTransactions({ page: "0" });
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("VALIDATION_ERROR");
+		}
+	});
+
+	it("DBエラー時にエラー詳細を漏洩しない", async () => {
+		mockAuthSuccess();
+		createChainMock({
+			data: null,
+			count: null,
+			error: { code: "42501", message: "RLS violation" },
+		});
+
+		const result = await getTransactions({});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).not.toContain("RLS violation");
+		}
+	});
+});

--- a/app/_actions/transaction-actions.ts
+++ b/app/_actions/transaction-actions.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import { handleApiError } from "@/lib/api/error";
+import { requireAuth } from "@/lib/auth";
+import { createClient } from "@/lib/supabase/server";
+import type { ApiResponse } from "@/lib/types/api";
+import type { Tables } from "@/lib/types/supabase";
+import { getTransactionsSchema } from "@/lib/validators/transaction";
+
+type Transaction = Tables<"transactions">;
+
+export interface PaginatedTransactions {
+	transactions: Transaction[];
+	total: number;
+	page: number;
+	perPage: number;
+}
+
+export async function getTransactions(
+	params: Record<string, string | undefined>,
+): Promise<ApiResponse<PaginatedTransactions>> {
+	try {
+		const authResult = await requireAuth();
+		if (!authResult.success) return authResult;
+
+		const parsed = getTransactionsSchema.safeParse(params);
+		if (!parsed.success) {
+			return {
+				success: false,
+				error: "検索条件を確認してください。",
+				code: "VALIDATION_ERROR",
+			};
+		}
+
+		const { page, perPage, startDate, endDate, isConfirmed, accountCategory, sortBy, sortOrder } =
+			parsed.data;
+
+		const supabase = await createClient();
+
+		let query = supabase.from("transactions").select("*", { count: "exact" });
+
+		if (startDate) {
+			query = query.gte("transaction_date", startDate);
+		}
+		if (endDate) {
+			query = query.lte("transaction_date", endDate);
+		}
+		if (isConfirmed !== "all") {
+			query = query.eq("is_confirmed", isConfirmed === "true");
+		}
+		if (accountCategory) {
+			query = query.or(`debit_account.eq.${accountCategory},credit_account.eq.${accountCategory}`);
+		}
+
+		query = query.order(sortBy, { ascending: sortOrder === "asc" });
+
+		const from = (page - 1) * perPage;
+		const to = from + perPage - 1;
+		const { data, error, count } = await query.range(from, to);
+
+		if (error) return handleApiError(error);
+
+		return {
+			success: true,
+			data: {
+				transactions: data ?? [],
+				total: count ?? 0,
+				page,
+				perPage,
+			},
+		};
+	} catch (error) {
+		return handleApiError(error);
+	}
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BookOpen, LayoutDashboard, Settings } from "lucide-react";
+import { BookOpen, LayoutDashboard, List, Settings } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
@@ -22,6 +22,11 @@ const navItems = [
 		label: "ダッシュボード",
 		href: "/dashboard",
 		icon: LayoutDashboard,
+	},
+	{
+		label: "取引一覧",
+		href: "/transactions",
+		icon: List,
 	},
 	{
 		label: "設定",

--- a/lib/validators/transaction.ts
+++ b/lib/validators/transaction.ts
@@ -47,6 +47,25 @@ export const aiClassifyRequestSchema = z.object({
 
 export type AiClassifyRequestInput = z.infer<typeof aiClassifyRequestSchema>;
 
+export const getTransactionsSchema = z.object({
+	page: z.coerce.number().int().min(1).default(1),
+	perPage: z.coerce.number().int().min(1).max(100).default(20),
+	startDate: z
+		.string()
+		.regex(/^\d{4}-\d{2}-\d{2}$/)
+		.optional(),
+	endDate: z
+		.string()
+		.regex(/^\d{4}-\d{2}-\d{2}$/)
+		.optional(),
+	isConfirmed: z.enum(["true", "false", "all"]).default("all"),
+	accountCategory: z.string().optional(),
+	sortBy: z.enum(["transaction_date", "amount", "created_at"]).default("transaction_date"),
+	sortOrder: z.enum(["asc", "desc"]).default("desc"),
+});
+
+export type GetTransactionsInput = z.infer<typeof getTransactionsSchema>;
+
 export const exportRequestSchema = z.object({
 	format: z.enum(["yayoi", "freee", "generic"]),
 	startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),


### PR DESCRIPTION
## Summary
- `getTransactions` Server Action: 日付範囲・確認状態・勘定科目フィルタ + ソート + ページネーション
- `getTransactionsSchema` バリデータ追加（URL params 対応）
- 取引一覧ページ（Server Component, shadcn Table/Badge）
- サイドバーに「取引一覧」ナビ追加

## Related Issue
Closes #10

## Changes
| ファイル | 操作 |
|---------|------|
| `lib/validators/transaction.ts` | 修正: getTransactionsSchema 追加 |
| `app/_actions/transaction-actions.ts` | 新規: getTransactions Server Action |
| `app/_actions/__tests__/transaction-actions.test.ts` | 新規: テスト10件 |
| `app/(app)/transactions/page.tsx` | 新規: 取引一覧ページ |
| `components/app-sidebar.tsx` | 修正: 取引一覧ナビ追加 |

## Test plan
- [x] `npm run typecheck` — 型エラー 0 件
- [x] `npm run lint` — Biome エラー 0 件
- [x] `npm run test:unit` — 全 69 テスト通過（10件追加）
- [x] `npm run build` — ビルド成功
- [x] `git diff --stat` — 229 lines / 4 files（テスト除外後）
- [x] transaction-actions.ts カバレッジ: Stmt 96%, Branch 89%, Func 100%, Lines 96%

### TDD サイクル
1. RED: テスト10件作成 → 9件失敗確認
2. GREEN: getTransactions 実装 → 全10件通過
3. REFACTOR: Biome format + カバレッジ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)