### PR TITLE
feat: 取引作成・編集フォーム UI (TransactionForm + ページ)

### DIFF
--- a/app/(app)/transactions/[id]/page.tsx
+++ b/app/(app)/transactions/[id]/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation";
+import { getTransaction } from "@/app/_actions/transaction-actions";
+import { TransactionForm } from "@/components/transaction-form";
+import { getUser } from "@/lib/auth";
+
+interface PageProps {
+	params: Promise<{ id: string }>;
+}
+
+export default async function EditTransactionPage({ params }: PageProps) {
+	const user = await getUser();
+	if (!user) redirect("/login");
+
+	const { id } = await params;
+	const result = await getTransaction(id);
+
+	if (!result.success) {
+		return (
+			<div className="flex flex-col gap-6 p-4 md:p-6">
+				<p className="text-sm text-destructive">{result.error}</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-6 p-4 md:p-6">
+			<TransactionForm transaction={result.data} />
+		</div>
+	);
+}

--- a/app/(app)/transactions/new/page.tsx
+++ b/app/(app)/transactions/new/page.tsx
@@ -1,0 +1,14 @@
+import { redirect } from "next/navigation";
+import { TransactionForm } from "@/components/transaction-form";
+import { getUser } from "@/lib/auth";
+
+export default async function NewTransactionPage() {
+	const user = await getUser();
+	if (!user) redirect("/login");
+
+	return (
+		<div className="flex flex-col gap-6 p-4 md:p-6">
+			<TransactionForm />
+		</div>
+	);
+}

--- a/app/(app)/transactions/page.tsx
+++ b/app/(app)/transactions/page.tsx
@@ -1,7 +1,9 @@
+import { Plus } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getTransactions } from "@/app/_actions/transaction-actions";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
 	Table,
 	TableBody,
@@ -57,9 +59,17 @@ export default async function TransactionsPage({ searchParams }: PageProps) {
 
 	return (
 		<div className="flex flex-col gap-6 p-4 md:p-6">
-			<div>
-				<h1 className="text-xl font-bold tracking-tight">取引一覧</h1>
-				<p className="text-sm text-muted-foreground">{total}件の取引</p>
+			<div className="flex items-center justify-between">
+				<div>
+					<h1 className="text-xl font-bold tracking-tight">取引一覧</h1>
+					<p className="text-sm text-muted-foreground">{total}件の取引</p>
+				</div>
+				<Button asChild size="sm">
+					<Link href="/transactions/new">
+						<Plus className="mr-1 size-4" />
+						新規作成
+					</Link>
+				</Button>
 			</div>
 
 			{transactions.length === 0 ? (
@@ -81,9 +91,17 @@ export default async function TransactionsPage({ searchParams }: PageProps) {
 						</TableHeader>
 						<TableBody>
 							{transactions.map((tx) => (
-								<TableRow key={tx.id}>
-									<TableCell className="whitespace-nowrap">{tx.transaction_date}</TableCell>
-									<TableCell>{tx.description}</TableCell>
+								<TableRow key={tx.id} className="cursor-pointer">
+									<TableCell className="whitespace-nowrap">
+										<Link href={`/transactions/${tx.id}`} className="hover:underline">
+											{tx.transaction_date}
+										</Link>
+									</TableCell>
+									<TableCell>
+										<Link href={`/transactions/${tx.id}`} className="hover:underline">
+											{tx.description}
+										</Link>
+									</TableCell>
 									<TableCell className="text-right whitespace-nowrap">
 										{tx.amount.toLocaleString()}円
 									</TableCell>

--- a/components/transaction-form.tsx
+++ b/components/transaction-form.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { createTransaction, updateTransaction } from "@/app/_actions/transaction-actions";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import type { Tables } from "@/lib/types/supabase";
+import { ACCOUNT_CATEGORIES, TAX_CATEGORIES } from "@/lib/utils/constants";
+
+type Transaction = Tables<"transactions">;
+
+const ACCOUNT_TYPE_LABELS: Record<string, string> = {
+	expense: "経費",
+	income: "収益",
+	asset: "資産",
+	liability: "負債",
+};
+
+function AccountSelect({
+	id,
+	label,
+	value,
+	onValueChange,
+}: {
+	id: string;
+	label: string;
+	value: string;
+	onValueChange: (v: string) => void;
+}) {
+	const grouped = Object.groupBy(Object.entries(ACCOUNT_CATEGORIES), ([, v]) => v.type);
+
+	return (
+		<div className="space-y-2">
+			<Label htmlFor={id}>{label}</Label>
+			<Select value={value} onValueChange={onValueChange}>
+				<SelectTrigger id={id}>
+					<SelectValue placeholder="勘定科目を選択" />
+				</SelectTrigger>
+				<SelectContent>
+					{Object.entries(grouped).map(([type, entries]) => (
+						<SelectGroup key={type}>
+							<SelectLabel>{ACCOUNT_TYPE_LABELS[type] ?? type}</SelectLabel>
+							{entries?.map(([code, { name }]) => (
+								<SelectItem key={code} value={code}>
+									{name}
+								</SelectItem>
+							))}
+						</SelectGroup>
+					))}
+				</SelectContent>
+			</Select>
+		</div>
+	);
+}
+
+interface TransactionFormProps {
+	transaction?: Transaction;
+}
+
+export function TransactionForm({ transaction }: TransactionFormProps) {
+	const router = useRouter();
+	const isEdit = !!transaction;
+
+	const [transactionDate, setTransactionDate] = useState(transaction?.transaction_date ?? "");
+	const [description, setDescription] = useState(transaction?.description ?? "");
+	const [amount, setAmount] = useState(transaction?.amount?.toString() ?? "");
+	const [debitAccount, setDebitAccount] = useState(transaction?.debit_account ?? "");
+	const [creditAccount, setCreditAccount] = useState(transaction?.credit_account ?? "");
+	const [taxCategory, setTaxCategory] = useState(transaction?.tax_category ?? "");
+	const [memo, setMemo] = useState(transaction?.memo ?? "");
+	const [error, setError] = useState("");
+	const [loading, setLoading] = useState(false);
+
+	async function handleSubmit() {
+		setError("");
+		setLoading(true);
+
+		const input = {
+			transactionDate,
+			description,
+			amount: Number(amount),
+			debitAccount,
+			creditAccount,
+			...(taxCategory && { taxCategory }),
+			...(memo && { memo }),
+		};
+
+		const result = isEdit
+			? await updateTransaction({ id: transaction.id, ...input })
+			: await createTransaction(input);
+
+		if (result.success) {
+			router.push("/transactions");
+		} else {
+			setError(result.error);
+		}
+		setLoading(false);
+	}
+
+	return (
+		<Card className="max-w-lg">
+			<CardHeader>
+				<CardTitle>{isEdit ? "取引編集" : "新規取引"}</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<form action={handleSubmit} className="space-y-4">
+					<div className="space-y-2">
+						<Label htmlFor="transactionDate">日付</Label>
+						<Input
+							id="transactionDate"
+							type="date"
+							value={transactionDate}
+							onChange={(e) => setTransactionDate(e.target.value)}
+							required
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="description">摘要</Label>
+						<Input
+							id="description"
+							type="text"
+							value={description}
+							onChange={(e) => setDescription(e.target.value)}
+							maxLength={200}
+							placeholder="取引の内容を入力"
+							required
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="amount">金額（円）</Label>
+						<Input
+							id="amount"
+							type="number"
+							value={amount}
+							onChange={(e) => setAmount(e.target.value)}
+							min={1}
+							max={999999999}
+							placeholder="0"
+							required
+						/>
+					</div>
+
+					<AccountSelect
+						id="debitAccount"
+						label="借方勘定科目"
+						value={debitAccount}
+						onValueChange={setDebitAccount}
+					/>
+
+					<AccountSelect
+						id="creditAccount"
+						label="貸方勘定科目"
+						value={creditAccount}
+						onValueChange={setCreditAccount}
+					/>
+
+					<div className="space-y-2">
+						<Label htmlFor="taxCategory">税区分（任意）</Label>
+						<Select value={taxCategory} onValueChange={setTaxCategory}>
+							<SelectTrigger id="taxCategory">
+								<SelectValue placeholder="選択なし" />
+							</SelectTrigger>
+							<SelectContent>
+								{Object.entries(TAX_CATEGORIES).map(([key, { name }]) => (
+									<SelectItem key={key} value={key}>
+										{name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="memo">メモ（任意）</Label>
+						<Textarea
+							id="memo"
+							value={memo}
+							onChange={(e) => setMemo(e.target.value)}
+							maxLength={500}
+							placeholder="メモを入力"
+							rows={2}
+						/>
+					</div>
+
+					{error && <p className="text-sm text-destructive">{error}</p>}
+
+					<div className="flex gap-2">
+						<Button type="submit" disabled={loading} className="flex-1">
+							{loading ? "保存中..." : "保存"}
+						</Button>
+						<Button type="button" variant="outline" onClick={() => router.push("/transactions")}>
+							キャンセル
+						</Button>
+					</div>
+				</form>
+			</CardContent>
+		</Card>
+	);
+}


### PR DESCRIPTION
## 概要
取引の作成・編集 UI を実装（Issue #11 の 2/2）。

- `TransactionForm` コンポーネント（勘定科目グループ別セレクター付き）
- `/transactions/new`: 新規取引作成ページ
- `/transactions/[id]`: 取引編集ページ
- 取引一覧に「新規作成」ボタン + テーブル行に編集リンク追加

## 変更内容
- `components/transaction-form.tsx`: 新規作成/編集兼用フォームコンポーネント
- `app/(app)/transactions/new/page.tsx`: 新規作成ページ（Server Component）
- `app/(app)/transactions/[id]/page.tsx`: 編集ページ（Server Component）
- `app/(app)/transactions/page.tsx`: 新規作成ボタン + 編集リンク追加

## 機能詳細
- 7フィールド: 日付、摘要、金額、借方勘定科目、貸方勘定科目、税区分（任意）、メモ（任意）
- 勘定科目は経費/収益/資産/負債のグループ別表示
- 保存後に `/transactions` へリダイレクト
- 編集画面は既存データをプリフィル
- エラーメッセージ表示対応

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run test:unit` — 81/81 passed
- [x] `npm run build` — 成功（/transactions, /transactions/new, /transactions/[id] 全てデプロイ可）
- [x] PR サイズ: 282行 / 4ファイル

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)