### PR TITLE
feat: Claude API 連携 - 仕訳推定ロジック (#13)

### DIFF
--- a/lib/claude/__tests__/client.test.ts
+++ b/lib/claude/__tests__/client.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCreate } = vi.hoisted(() => ({
+	mockCreate: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+	class MockAnthropic {
+		messages = { create: mockCreate };
+	}
+	return { default: MockAnthropic };
+});
+
+import { classifyTransactions } from "@/lib/claude/client";
+import type { TransactionInput } from "@/lib/claude/types";
+
+const UUID_1 = "550e8400-e29b-41d4-a716-446655440000";
+const UUID_2 = "550e8400-e29b-41d4-a716-446655440001";
+
+const sampleInput: TransactionInput[] = [
+	{
+		id: UUID_1,
+		date: "2026-01-15",
+		description: "AWS利用料",
+		amount: 5000,
+	},
+];
+
+const validApiResponse = {
+	content: [
+		{
+			type: "text",
+			text: JSON.stringify({
+				classifications: [
+					{
+						id: UUID_1,
+						debitAccount: "EXP001",
+						creditAccount: "AST002",
+						confidence: "HIGH",
+						reason: "クラウドサービス利用料は通信費に該当",
+					},
+				],
+			}),
+		},
+	],
+	stop_reason: "end_turn",
+};
+
+describe("classifyTransactions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("単一取引の仕訳を推定できる", async () => {
+		mockCreate.mockResolvedValue(validApiResponse);
+
+		const result = await classifyTransactions(sampleInput);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toHaveLength(1);
+			expect(result.data[0].debitAccount).toBe("EXP001");
+			expect(result.data[0].creditAccount).toBe("AST002");
+			expect(result.data[0].confidence).toBe("HIGH");
+			expect(result.data[0].reason).toBeTruthy();
+		}
+	});
+
+	it("複数取引を一括で推定できる", async () => {
+		const multiInput: TransactionInput[] = [
+			{ id: UUID_1, date: "2026-01-15", description: "AWS利用料", amount: 5000 },
+			{ id: UUID_2, date: "2026-01-16", description: "電車代", amount: 500 },
+		];
+		mockCreate.mockResolvedValue({
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify({
+						classifications: [
+							{
+								id: UUID_1,
+								debitAccount: "EXP001",
+								creditAccount: "AST002",
+								confidence: "HIGH",
+								reason: "クラウドサービス",
+							},
+							{
+								id: UUID_2,
+								debitAccount: "EXP003",
+								creditAccount: "AST001",
+								confidence: "HIGH",
+								reason: "交通費",
+							},
+						],
+					}),
+				},
+			],
+			stop_reason: "end_turn",
+		});
+
+		const result = await classifyTransactions(multiInput);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toHaveLength(2);
+			expect(result.data[0].debitAccount).toBe("EXP001");
+			expect(result.data[1].debitAccount).toBe("EXP003");
+		}
+	});
+
+	it("messages.create にシステムプロンプトが含まれる", async () => {
+		mockCreate.mockResolvedValue(validApiResponse);
+
+		await classifyTransactions(sampleInput);
+
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining("勘定科目"),
+			}),
+		);
+	});
+
+	it("APIエラー時にAI_ERRORを返す", async () => {
+		mockCreate.mockRejectedValue(new Error("API connection failed"));
+
+		const result = await classifyTransactions(sampleInput);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("AI_ERROR");
+			expect(result.error).not.toContain("API connection failed");
+		}
+	});
+
+	it("レート制限エラー(429)時に適切なメッセージを返す", async () => {
+		const rateLimitError = new Error("rate limit");
+		Object.assign(rateLimitError, { status: 429 });
+		mockCreate.mockRejectedValue(rateLimitError);
+
+		const result = await classifyTransactions(sampleInput);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("RATE_LIMIT");
+		}
+	});
+
+	it("不正なAPIレスポンスでエラーを返す", async () => {
+		mockCreate.mockResolvedValue({
+			content: [{ type: "text", text: "これはJSONではありません" }],
+			stop_reason: "end_turn",
+		});
+
+		const result = await classifyTransactions(sampleInput);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("AI_ERROR");
+		}
+	});
+
+	it("空の取引配列でバリデーションエラーを返す", async () => {
+		const result = await classifyTransactions([]);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("VALIDATION_ERROR");
+		}
+	});
+
+	it("50件超の取引でバリデーションエラーを返す", async () => {
+		const manyInputs: TransactionInput[] = Array.from({ length: 51 }, (_, i) => ({
+			date: "2026-01-15",
+			description: `取引${i}`,
+			amount: 1000,
+		}));
+
+		const result = await classifyTransactions(manyInputs);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("VALIDATION_ERROR");
+		}
+	});
+
+	it("エラー詳細を漏洩しない", async () => {
+		mockCreate.mockRejectedValue(new Error("secret internal error details"));
+
+		const result = await classifyTransactions(sampleInput);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).not.toContain("secret");
+			expect(result.error).not.toContain("internal");
+		}
+	});
+});

--- a/lib/claude/client.ts
+++ b/lib/claude/client.ts
@@ -1,0 +1,74 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { ApiError, handleApiError } from "@/lib/api/error";
+import type { ApiResponse } from "@/lib/types/api";
+import { aiClassifyRequestSchema } from "@/lib/validators/transaction";
+import { buildUserPrompt, SYSTEM_PROMPT } from "./prompts";
+import {
+	type ClassifiedTransaction,
+	classificationResultSchema,
+	type TransactionInput,
+} from "./types";
+
+export async function classifyTransactions(
+	transactions: TransactionInput[],
+): Promise<ApiResponse<ClassifiedTransaction[]>> {
+	try {
+		const parsed = aiClassifyRequestSchema.safeParse({ transactions });
+		if (!parsed.success) {
+			return { success: false, error: "入力内容を確認してください。", code: "VALIDATION_ERROR" };
+		}
+
+		const client = new Anthropic();
+		const response = await client.messages.create({
+			model: "claude-sonnet-4-5-20250929",
+			max_tokens: 4096,
+			system: SYSTEM_PROMPT,
+			messages: [{ role: "user", content: buildUserPrompt(parsed.data.transactions) }],
+		});
+
+		const textBlock = response.content.find(
+			(block): block is Anthropic.TextBlock => block.type === "text",
+		);
+		if (!textBlock) {
+			throw new ApiError("AI_ERROR", "AIからの応答を取得できませんでした。");
+		}
+
+		let json: unknown;
+		try {
+			json = JSON.parse(textBlock.text);
+		} catch {
+			throw new ApiError("AI_ERROR", "AIの応答形式が不正です。");
+		}
+		const result = classificationResultSchema.safeParse(json);
+		if (!result.success) {
+			throw new ApiError("AI_ERROR", "AIの応答形式が不正です。");
+		}
+
+		return { success: true, data: result.data.classifications };
+	} catch (error) {
+		if (isRateLimitError(error)) {
+			return {
+				success: false,
+				error: "リクエスト制限に達しました。しばらく待ってから再試行してください。",
+				code: "RATE_LIMIT",
+			};
+		}
+		if (error instanceof ApiError) {
+			return handleApiError(error);
+		}
+		return {
+			success: false,
+			error: "AI仕訳推定に失敗しました。",
+			code: "AI_ERROR",
+		};
+	}
+}
+
+function isRateLimitError(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"status" in error &&
+		(error as { status: number }).status === 429
+	);
+}

--- a/lib/claude/prompts.ts
+++ b/lib/claude/prompts.ts
@@ -1,0 +1,30 @@
+import { ACCOUNT_CATEGORIES } from "@/lib/utils/constants";
+import type { TransactionInput } from "./types";
+
+const accountList = Object.entries(ACCOUNT_CATEGORIES)
+	.map(([code, info]) => `${code}: ${info.name}（${info.type}）`)
+	.join("\n");
+
+export const SYSTEM_PROMPT = `あなたは日本のフリーランスIT技術者向けの確定申告アシスタントです。
+取引の摘要から適切な勘定科目を推定してください。
+
+## 使用可能な勘定科目コード
+${accountList}
+
+## ルール
+- 借方（debitAccount）と貸方（creditAccount）の勘定科目コードを返してください
+- 確信度（confidence）を HIGH / MEDIUM / LOW で返してください
+- 推定理由（reason）を簡潔に日本語で返してください
+- 不明な場合は confidence を LOW にしてください
+- 費用の支払いは通常: 借方=費用科目、貸方=資産科目（普通預金など）
+- 収入の受取は通常: 借方=資産科目、貸方=収入科目`;
+
+export function buildUserPrompt(transactions: TransactionInput[]): string {
+	const items = transactions
+		.map(
+			(tx, i) => `${i + 1}. [${tx.id ?? "no-id"}] ${tx.date} | ${tx.description} | ${tx.amount}円`,
+		)
+		.join("\n");
+
+	return `以下の取引の仕訳を推定してください:\n\n${items}`;
+}

--- a/lib/claude/types.ts
+++ b/lib/claude/types.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import { ACCOUNT_CATEGORIES } from "@/lib/utils/constants";
+
+const accountCodes = Object.keys(ACCOUNT_CATEGORIES) as [string, ...string[]];
+
+export const classificationResultSchema = z.object({
+	classifications: z.array(
+		z.object({
+			id: z.string().optional(),
+			debitAccount: z.enum(accountCodes),
+			creditAccount: z.enum(accountCodes),
+			confidence: z.enum(["HIGH", "MEDIUM", "LOW"]),
+			reason: z.string(),
+		}),
+	),
+});
+
+export type ClassificationResult = z.infer<typeof classificationResultSchema>;
+
+export interface TransactionInput {
+	id?: string;
+	date: string;
+	description: string;
+	amount: number;
+}
+
+export interface ClassifiedTransaction {
+	id?: string;
+	debitAccount: string;
+	creditAccount: string;
+	confidence: "HIGH" | "MEDIUM" | "LOW";
+	reason: string;
+}


### PR DESCRIPTION
## 概要

Claude API を使用した仕訳推定ロジックを TDD で実装。
取引の摘要から適切な勘定科目・確信度を AI で推定する KanjouAI のコア機能。

## 変更内容

### `lib/claude/client.ts` — メインロジック
- `classifyTransactions()`: 取引配列を受け取り、AI で勘定科目を推定
- 入力バリデーション（Zod、1〜50件）
- レスポンスの JSON パース + スキーマ検証
- レート制限エラー (429) の適切なハンドリング
- API エラー時のセキュアなエラー返却（詳細非漏洩）

### `lib/claude/prompts.ts` — プロンプト生成
- システムプロンプト: 勘定科目マスタ（`constants.ts`）を日本語で参照
- ユーザープロンプト: 取引リストのフォーマット

### `lib/claude/types.ts` — 型定義
- `ClassificationResult`: Zod スキーマ（勘定科目コード enum + 確信度）
- `TransactionInput` / `ClassifiedTransaction` インターフェース

## テスト結果

| 指標 | 値 |
|------|------|
| テストケース数（新規） | 9件 |
| Statements（client.ts） | 91.3% |
| Branches | 85.71% |
| Functions | 100% |
| Lines | 91.3% |
| TypeScript 型エラー | 0件 |
| Lint エラー | 0件 |
| 全ユニットテスト | 107件 PASS |

### テスト観点（Issue 受け入れ条件）

- [x] 正常系: 単一取引の仕訳推定
- [x] 正常系: 複数取引の一括推定
- [x] 正常系: システムプロンプトに勘定科目が含まれる
- [x] 異常系: API エラー → AI_ERROR
- [x] 異常系: レート制限 (429) → RATE_LIMIT
- [x] 異常系: 不正な API レスポンス → AI_ERROR
- [x] エッジケース: 空配列 → VALIDATION_ERROR
- [x] エッジケース: 50件超 → VALIDATION_ERROR
- [x] セキュリティ: エラー詳細の非漏洩

## PR サイズ

4 files changed, 334 insertions(+)

> 300行超の理由: テストコード197行（59%）を含む。実装コードは137行。

## 関連

- Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)