### PR TITLE
feat: AI仕訳推定の確認モーダル（Issue #47 Phase 1）

### DIFF
--- a/app/_actions/__tests__/ai-classify-actions.test.ts
+++ b/app/_actions/__tests__/ai-classify-actions.test.ts
@@ -17,7 +17,7 @@ vi.mock("next/cache", () => ({
 }));
 
 import { revalidatePath } from "next/cache";
-import { runAiClassification } from "@/app/_actions/ai-classify-actions";
+import { applyAiClassifications, runAiClassification } from "@/app/_actions/ai-classify-actions";
 import { requireAuth } from "@/lib/auth";
 import { classifyTransactions } from "@/lib/claude/client";
 import { createClient } from "@/lib/supabase/server";
@@ -63,31 +63,18 @@ function createSelectMock(
 	return { mock, mockFrom };
 }
 
-function createSelectAndUpdateMock(
-	selectData: unknown[],
-	_updateData: unknown[] | null = null,
-	updateError: { code: string; message: string } | null = null,
-) {
+function createUpdateMock(updateError: { code: string; message: string } | null = null) {
 	const updateChain: Record<string, ReturnType<typeof vi.fn>> = {};
 	updateChain.update = vi.fn().mockReturnValue(updateChain);
 	updateChain.eq = vi.fn().mockResolvedValue({ error: updateError });
 
-	const selectChain: Record<string, ReturnType<typeof vi.fn>> = {};
-	selectChain.select = vi.fn().mockReturnValue(selectChain);
-	selectChain.in = vi.fn().mockResolvedValue({ data: selectData, error: null });
-
-	let callCount = 0;
-	const mockFrom = vi.fn().mockImplementation(() => {
-		callCount++;
-		if (callCount === 1) return selectChain;
-		return updateChain;
-	});
+	const mockFrom = vi.fn().mockReturnValue(updateChain);
 
 	mockCreateClient.mockResolvedValue({
 		from: mockFrom,
 	} as unknown as Awaited<ReturnType<typeof createClient>>);
 
-	return { mockFrom, selectChain, updateChain };
+	return { mockFrom, updateChain };
 }
 
 const dbTransaction1 = {
@@ -119,25 +106,9 @@ describe("runAiClassification", () => {
 		vi.clearAllMocks();
 	});
 
-	it("正常推定: AI分類結果を返しDBを更新する", async () => {
+	it("正常推定: AI分類結果にdescriptionとamountを含めて返す", async () => {
 		mockAuthSuccess();
-		const updatedTxs = [
-			{
-				...dbTransaction1,
-				debit_account: "EXP001",
-				credit_account: "AST002",
-				ai_suggested: true,
-				ai_confidence: 0.9,
-			},
-			{
-				...dbTransaction2,
-				debit_account: "EXP003",
-				credit_account: "AST001",
-				ai_suggested: true,
-				ai_confidence: 0.9,
-			},
-		];
-		createSelectAndUpdateMock([dbTransaction1, dbTransaction2], updatedTxs);
+		createSelectMock([dbTransaction1, dbTransaction2]);
 		mockClassify.mockResolvedValue({
 			success: true,
 			data: [
@@ -163,10 +134,43 @@ describe("runAiClassification", () => {
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data).toHaveLength(2);
-			expect(result.data[0].debitAccount).toBe("EXP001");
-			expect(result.data[0].confidence).toBe("HIGH");
-			expect(result.data[1].debitAccount).toBe("EXP003");
+			expect(result.data[0]).toMatchObject({
+				id: UUID_1,
+				description: "AWS利用料",
+				amount: 5000,
+				debitAccount: "EXP001",
+				creditAccount: "AST002",
+				confidence: "HIGH",
+				reason: "クラウドサービス利用料",
+			});
+			expect(result.data[1]).toMatchObject({
+				id: UUID_2,
+				description: "電車代",
+				amount: 500,
+				debitAccount: "EXP003",
+			});
 		}
+	});
+
+	it("DBに保存しない（revalidatePathを呼ばない）", async () => {
+		mockAuthSuccess();
+		createSelectMock([dbTransaction1]);
+		mockClassify.mockResolvedValue({
+			success: true,
+			data: [
+				{
+					id: UUID_1,
+					debitAccount: "EXP001",
+					creditAccount: "AST002",
+					confidence: "HIGH",
+					reason: "理由",
+				},
+			],
+		});
+
+		await runAiClassification([UUID_1]);
+
+		expect(mockRevalidatePath).not.toHaveBeenCalled();
 	});
 
 	it("AI APIエラー時にAI_ERRORを返す", async () => {
@@ -223,52 +227,6 @@ describe("runAiClassification", () => {
 		}
 	});
 
-	it("DB更新エラー時にエラーを返す", async () => {
-		mockAuthSuccess();
-		createSelectAndUpdateMock([dbTransaction1], null, {
-			code: "42501",
-			message: "permission denied",
-		});
-		mockClassify.mockResolvedValue({
-			success: true,
-			data: [
-				{
-					id: UUID_1,
-					debitAccount: "EXP001",
-					creditAccount: "AST002",
-					confidence: "HIGH",
-					reason: "理由",
-				},
-			],
-		});
-
-		const result = await runAiClassification([UUID_1]);
-
-		expect(result.success).toBe(false);
-	});
-
-	it("revalidatePathが呼ばれる", async () => {
-		mockAuthSuccess();
-		const updatedTx = { ...dbTransaction1, ai_suggested: true, ai_confidence: 90 };
-		createSelectAndUpdateMock([dbTransaction1], [updatedTx]);
-		mockClassify.mockResolvedValue({
-			success: true,
-			data: [
-				{
-					id: UUID_1,
-					debitAccount: "EXP001",
-					creditAccount: "AST002",
-					confidence: "HIGH",
-					reason: "理由",
-				},
-			],
-		});
-
-		await runAiClassification([UUID_1]);
-
-		expect(mockRevalidatePath).toHaveBeenCalledWith("/transactions");
-	});
-
 	it("エラー詳細を漏洩しない", async () => {
 		mockAuthSuccess();
 		createSelectMock([dbTransaction1]);
@@ -284,6 +242,108 @@ describe("runAiClassification", () => {
 		if (!result.success) {
 			expect(result.error).not.toContain("secret");
 			expect(result.error).not.toContain("internal");
+		}
+	});
+});
+
+describe("applyAiClassifications", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("正常適用: 分類結果をDBに保存しis_confirmedをtrueにする", async () => {
+		mockAuthSuccess();
+		const { updateChain } = createUpdateMock();
+
+		const result = await applyAiClassifications([
+			{ id: UUID_1, debitAccount: "EXP001", creditAccount: "AST002", confidence: "HIGH" },
+		]);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toBe(1);
+		}
+		expect(updateChain.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				debit_account: "EXP001",
+				credit_account: "AST002",
+				ai_suggested: true,
+				is_confirmed: true,
+			}),
+		);
+	});
+
+	it("認証エラー時にUNAUTHORIZEDを返す", async () => {
+		mockAuthFailure();
+
+		const result = await applyAiClassifications([
+			{ id: UUID_1, debitAccount: "EXP001", creditAccount: "AST002", confidence: "HIGH" },
+		]);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("UNAUTHORIZED");
+		}
+	});
+
+	it("空配列でバリデーションエラーを返す", async () => {
+		mockAuthSuccess();
+
+		const result = await applyAiClassifications([]);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("VALIDATION_ERROR");
+		}
+	});
+
+	it("無効な勘定科目でバリデーションエラーを返す", async () => {
+		mockAuthSuccess();
+
+		const result = await applyAiClassifications([
+			{ id: UUID_1, debitAccount: "INVALID", creditAccount: "AST002", confidence: "HIGH" },
+		]);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("VALIDATION_ERROR");
+		}
+	});
+
+	it("DB更新エラー時にエラーを返す", async () => {
+		mockAuthSuccess();
+		createUpdateMock({ code: "42501", message: "permission denied" });
+
+		const result = await applyAiClassifications([
+			{ id: UUID_1, debitAccount: "EXP001", creditAccount: "AST002", confidence: "HIGH" },
+		]);
+
+		expect(result.success).toBe(false);
+	});
+
+	it("適用後にrevalidatePathが呼ばれる", async () => {
+		mockAuthSuccess();
+		createUpdateMock();
+
+		await applyAiClassifications([
+			{ id: UUID_1, debitAccount: "EXP001", creditAccount: "AST002", confidence: "HIGH" },
+		]);
+
+		expect(mockRevalidatePath).toHaveBeenCalledWith("/transactions");
+	});
+
+	it("エラー詳細を漏洩しない", async () => {
+		mockAuthSuccess();
+		createUpdateMock({ code: "42501", message: "secret RLS violation details" });
+
+		const result = await applyAiClassifications([
+			{ id: UUID_1, debitAccount: "EXP001", creditAccount: "AST002", confidence: "HIGH" },
+		]);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error).not.toContain("secret");
+			expect(result.error).not.toContain("RLS");
 		}
 	});
 });

--- a/app/_actions/ai-classify-actions.ts
+++ b/app/_actions/ai-classify-actions.ts
@@ -7,7 +7,7 @@ import { classifyTransactions } from "@/lib/claude/client";
 import type { ClassifiedTransaction } from "@/lib/claude/types";
 import { createClient } from "@/lib/supabase/server";
 import type { ApiResponse } from "@/lib/types/api";
-import { bulkConfirmSchema } from "@/lib/validators/transaction";
+import { applyClassificationsSchema, bulkConfirmSchema } from "@/lib/validators/transaction";
 
 const CONFIDENCE_SCORE: Record<string, number> = {
 	HIGH: 0.9,
@@ -15,9 +15,19 @@ const CONFIDENCE_SCORE: Record<string, number> = {
 	LOW: 0.3,
 };
 
+export interface AiClassificationRow {
+	id: string;
+	description: string;
+	amount: number;
+	debitAccount: string;
+	creditAccount: string;
+	confidence: "HIGH" | "MEDIUM" | "LOW";
+	reason: string;
+}
+
 export async function runAiClassification(
 	ids: string[],
-): Promise<ApiResponse<ClassifiedTransaction[]>> {
+): Promise<ApiResponse<AiClassificationRow[]>> {
 	try {
 		const authResult = await requireAuth();
 		if (!authResult.success) return authResult;
@@ -62,23 +72,65 @@ export async function runAiClassification(
 			};
 		}
 
-		for (const classification of classifyResult.data) {
-			if (!classification.id) continue;
-			const score = CONFIDENCE_SCORE[classification.confidence] ?? 0;
+		const rows: AiClassificationRow[] = classifyResult.data
+			.filter((c): c is ClassifiedTransaction & { id: string } => !!c.id)
+			.map((c) => {
+				const tx = transactions.find((t) => t.id === c.id);
+				return {
+					id: c.id,
+					description: tx?.description ?? "",
+					amount: tx?.amount ?? 0,
+					debitAccount: c.debitAccount,
+					creditAccount: c.creditAccount,
+					confidence: c.confidence,
+					reason: c.reason,
+				};
+			});
+
+		return { success: true, data: rows };
+	} catch (error) {
+		return handleApiError(error);
+	}
+}
+
+export async function applyAiClassifications(
+	classifications: {
+		id: string;
+		debitAccount: string;
+		creditAccount: string;
+		confidence: string;
+	}[],
+): Promise<ApiResponse<number>> {
+	try {
+		const authResult = await requireAuth();
+		if (!authResult.success) return authResult;
+
+		const parsed = applyClassificationsSchema.safeParse({ classifications });
+		if (!parsed.success) {
+			return { success: false, error: "入力内容を確認してください。", code: "VALIDATION_ERROR" };
+		}
+
+		const supabase = await createClient();
+		let updatedCount = 0;
+
+		for (const item of parsed.data.classifications) {
+			const score = CONFIDENCE_SCORE[item.confidence] ?? 0;
 			const { error: updateError } = await supabase
 				.from("transactions")
 				.update({
-					debit_account: classification.debitAccount,
-					credit_account: classification.creditAccount,
+					debit_account: item.debitAccount,
+					credit_account: item.creditAccount,
 					ai_suggested: true,
 					ai_confidence: score,
+					is_confirmed: true,
 				})
-				.eq("id", classification.id);
+				.eq("id", item.id);
 			if (updateError) return handleApiError(updateError);
+			updatedCount++;
 		}
 
 		revalidatePath("/transactions");
-		return { success: true, data: classifyResult.data };
+		return { success: true, data: updatedCount };
 	} catch (error) {
 		return handleApiError(error);
 	}

--- a/components/ai-classify-dialog.tsx
+++ b/components/ai-classify-dialog.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState } from "react";
+import type { AiClassificationRow } from "@/app/_actions/ai-classify-actions";
+import { ACCOUNT_CATEGORIES } from "@/lib/utils/constants";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "./ui/dialog";
+import {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectTrigger,
+	SelectValue,
+} from "./ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./ui/table";
+
+const ACCOUNT_TYPE_LABELS: Record<string, string> = {
+	expense: "経費",
+	income: "収益",
+	asset: "資産",
+	liability: "負債",
+};
+
+interface EditableRow {
+	id: string;
+	debitAccount: string;
+	creditAccount: string;
+	confidence: "HIGH" | "MEDIUM" | "LOW";
+}
+
+function ConfidenceBadge({ confidence }: { confidence: "HIGH" | "MEDIUM" | "LOW" }) {
+	if (confidence === "HIGH") return <Badge className="bg-green-600 text-white">HIGH</Badge>;
+	if (confidence === "MEDIUM") return <Badge className="bg-yellow-500 text-white">MEDIUM</Badge>;
+	return <Badge className="bg-red-500 text-white">LOW</Badge>;
+}
+
+function AccountCodeSelect({
+	value,
+	onValueChange,
+}: {
+	value: string;
+	onValueChange: (v: string) => void;
+}) {
+	const grouped = Object.groupBy(Object.entries(ACCOUNT_CATEGORIES), ([, v]) => v.type);
+
+	return (
+		<Select value={value} onValueChange={onValueChange}>
+			<SelectTrigger className="h-8 w-[130px] text-xs">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				{Object.entries(grouped).map(([type, entries]) => (
+					<SelectGroup key={type}>
+						<SelectLabel>{ACCOUNT_TYPE_LABELS[type] ?? type}</SelectLabel>
+						{entries?.map(([code, { name }]) => (
+							<SelectItem key={code} value={code}>
+								{name}
+							</SelectItem>
+						))}
+					</SelectGroup>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+interface AiClassifyDialogProps {
+	results: AiClassificationRow[] | null;
+	open: boolean;
+	onClose: () => void;
+	onApply: (rows: EditableRow[]) => Promise<void>;
+}
+
+export function AiClassifyDialog({ results, open, onClose, onApply }: AiClassifyDialogProps) {
+	const [editable, setEditable] = useState<EditableRow[]>([]);
+	const [applying, setApplying] = useState(false);
+
+	function handleOpenChange(isOpen: boolean) {
+		if (isOpen && results) {
+			setEditable(
+				results.map((r) => ({
+					id: r.id,
+					debitAccount: r.debitAccount,
+					creditAccount: r.creditAccount,
+					confidence: r.confidence,
+				})),
+			);
+		}
+		if (!isOpen) onClose();
+	}
+
+	function updateRow(index: number, field: "debitAccount" | "creditAccount", value: string) {
+		setEditable((prev) => prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)));
+	}
+
+	async function handleApply() {
+		setApplying(true);
+		await onApply(editable);
+		setApplying(false);
+	}
+
+	if (!results) return null;
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogContent className="sm:max-w-4xl max-h-[80vh] overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>AI仕訳推定結果</DialogTitle>
+					<DialogDescription>
+						{results.length}件の推定結果を確認してください。科目は変更可能です。
+					</DialogDescription>
+				</DialogHeader>
+				<div className="rounded-lg border">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>摘要</TableHead>
+								<TableHead className="text-right">金額</TableHead>
+								<TableHead>借方</TableHead>
+								<TableHead>貸方</TableHead>
+								<TableHead>確度</TableHead>
+								<TableHead>理由</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{results.map((row, i) => (
+								<TableRow key={row.id}>
+									<TableCell className="max-w-[150px] truncate" title={row.description}>
+										{row.description}
+									</TableCell>
+									<TableCell className="text-right whitespace-nowrap">
+										{row.amount.toLocaleString()}円
+									</TableCell>
+									<TableCell>
+										<AccountCodeSelect
+											value={editable[i]?.debitAccount ?? row.debitAccount}
+											onValueChange={(v) => updateRow(i, "debitAccount", v)}
+										/>
+									</TableCell>
+									<TableCell>
+										<AccountCodeSelect
+											value={editable[i]?.creditAccount ?? row.creditAccount}
+											onValueChange={(v) => updateRow(i, "creditAccount", v)}
+										/>
+									</TableCell>
+									<TableCell>
+										<ConfidenceBadge confidence={row.confidence} />
+									</TableCell>
+									<TableCell
+										className="max-w-[150px] truncate text-sm text-muted-foreground"
+										title={row.reason}
+									>
+										{row.reason}
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</div>
+				<DialogFooter>
+					<Button variant="outline" onClick={onClose} disabled={applying}>
+						キャンセル
+					</Button>
+					<Button onClick={handleApply} disabled={applying}>
+						{applying ? "適用中…" : `${results.length}件を承認`}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/components/transaction-list-actions.tsx
+++ b/components/transaction-list-actions.tsx
@@ -3,7 +3,11 @@
 import { Check, CheckCheck, Sparkles, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
-import { runAiClassification } from "@/app/_actions/ai-classify-actions";
+import {
+	type AiClassificationRow,
+	applyAiClassifications,
+	runAiClassification,
+} from "@/app/_actions/ai-classify-actions";
 import {
 	bulkConfirmTransactions,
 	confirmTransaction,
@@ -12,6 +16,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import type { Tables } from "@/lib/types/supabase";
 import { ACCOUNT_CATEGORIES } from "@/lib/utils/constants";
+import { AiClassifyDialog } from "./ai-classify-dialog";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -49,6 +54,7 @@ interface TransactionListActionsProps {
 export function TransactionListActions({ transactions }: TransactionListActionsProps) {
 	const [selected, setSelected] = useState<Set<string>>(new Set());
 	const [loading, setLoading] = useState(false);
+	const [classifyResults, setClassifyResults] = useState<AiClassificationRow[] | null>(null);
 	const { toast } = useToast();
 
 	const unconfirmed = transactions.filter((tx) => !tx.is_confirmed);
@@ -113,10 +119,26 @@ export function TransactionListActions({ transactions }: TransactionListActionsP
 		const result = await runAiClassification([...selected]);
 		setLoading(false);
 		if (result.success) {
-			setSelected(new Set());
-			toast({ title: `${result.data.length}件の仕訳を推定しました` });
+			setClassifyResults(result.data);
 		} else {
 			toast({ title: "AI推定に失敗しました", description: result.error, variant: "destructive" });
+		}
+	}
+
+	async function handleApplyClassifications(
+		rows: { id: string; debitAccount: string; creditAccount: string; confidence: string }[],
+	) {
+		const result = await applyAiClassifications(rows);
+		if (result.success) {
+			setClassifyResults(null);
+			setSelected(new Set());
+			toast({ title: `${result.data}件の仕訳を適用しました` });
+		} else {
+			toast({
+				title: "仕訳の適用に失敗しました",
+				description: result.error,
+				variant: "destructive",
+			});
 		}
 	}
 
@@ -240,6 +262,13 @@ export function TransactionListActions({ transactions }: TransactionListActionsP
 					</TableBody>
 				</Table>
 			</div>
+
+			<AiClassifyDialog
+				results={classifyResults}
+				open={classifyResults !== null}
+				onClose={() => setClassifyResults(null)}
+				onApply={handleApplyClassifications}
+			/>
 		</>
 	);
 }

--- a/lib/validators/transaction.ts
+++ b/lib/validators/transaction.ts
@@ -82,3 +82,19 @@ export const exportRequestSchema = z.object({
 });
 
 export type ExportRequestInput = z.infer<typeof exportRequestSchema>;
+
+export const applyClassificationsSchema = z.object({
+	classifications: z
+		.array(
+			z.object({
+				id: z.string().uuid("無効なIDです"),
+				debitAccount: accountCodeSchema,
+				creditAccount: accountCodeSchema,
+				confidence: z.enum(["HIGH", "MEDIUM", "LOW"]),
+			}),
+		)
+		.min(1, "1件以上の分類を指定してください")
+		.max(50, "一度に処理できるのは50件までです"),
+});
+
+export type ApplyClassificationsInput = z.infer<typeof applyClassificationsSchema>;


### PR DESCRIPTION
## Summary
- `runAiClassification` を DB 保存なし（結果返却のみ）に変更し、推定結果をモーダルで確認できるようにした
- `applyAiClassifications` Server Action を追加（承認時に DB 更新 + `is_confirmed: true`）
- `AiClassifyDialog` コンポーネントを追加（推定結果テーブル + 科目修正ドロップダウン + 承認ボタン）

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `app/_actions/ai-classify-actions.ts` | `runAiClassification` から DB 保存削除、`AiClassificationRow` 型追加、`applyAiClassifications` 新規 |
| `app/_actions/__tests__/ai-classify-actions.test.ts` | 既存テスト更新 + `applyAiClassifications` テスト 7件追加（計14件） |
| `lib/validators/transaction.ts` | `applyClassificationsSchema` 追加 |
| `components/ai-classify-dialog.tsx` | 新規: 確認モーダル（shadcn Dialog + Table + Select） |
| `components/transaction-list-actions.tsx` | ダイアログ連携、`handleApplyClassifications` 追加 |

## Test plan
- [x] 全122テスト PASS
- [x] TypeScript 型エラー 0件
- [x] Biome lint エラー 0件
- [x] カバレッジ: Statements 91.29% / Branches 85.79% / Functions 97.5% / Lines 92.05%
- [ ] 手動確認: 取引選択 → AI推定ボタン → モーダル表示 → 科目変更 → 承認 → DB反映

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)