### PR TITLE
feat: 自然言語指示 + Phase 1 レビュー修正（Issue #47 Phase 2-A）

### DIFF
--- a/app/_actions/__tests__/ai-classify-actions.test.ts
+++ b/app/_actions/__tests__/ai-classify-actions.test.ts
@@ -244,6 +244,27 @@ describe("runAiClassification", () => {
 			expect(result.error).not.toContain("internal");
 		}
 	});
+
+	it("userInstructionをclassifyTransactionsに渡す", async () => {
+		mockAuthSuccess();
+		createSelectMock([dbTransaction1]);
+		mockClassify.mockResolvedValue({
+			success: true,
+			data: [
+				{
+					id: UUID_1,
+					debitAccount: "EXP001",
+					creditAccount: "AST002",
+					confidence: "HIGH",
+					reason: "理由",
+				},
+			],
+		});
+
+		await runAiClassification([UUID_1], "AWSは通信費にして");
+
+		expect(mockClassify).toHaveBeenCalledWith(expect.anything(), "AWSは通信費にして");
+	});
 });
 
 describe("applyAiClassifications", () => {
@@ -345,5 +366,39 @@ describe("applyAiClassifications", () => {
 			expect(result.error).not.toContain("secret");
 			expect(result.error).not.toContain("RLS");
 		}
+	});
+
+	it("MANUAL confidenceでai_confidence=1.0, ai_suggested=falseを設定する", async () => {
+		mockAuthSuccess();
+		const { updateChain } = createUpdateMock();
+
+		const result = await applyAiClassifications([
+			{ id: UUID_1, debitAccount: "EXP001", creditAccount: "AST002", confidence: "MANUAL" },
+		]);
+
+		expect(result.success).toBe(true);
+		expect(updateChain.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				ai_confidence: 1.0,
+				ai_suggested: false,
+				is_confirmed: true,
+			}),
+		);
+	});
+
+	it("複数件を並列で更新する", async () => {
+		mockAuthSuccess();
+		const { updateChain } = createUpdateMock();
+
+		const result = await applyAiClassifications([
+			{ id: UUID_1, debitAccount: "EXP001", creditAccount: "AST002", confidence: "HIGH" },
+			{ id: UUID_2, debitAccount: "EXP003", creditAccount: "AST001", confidence: "MEDIUM" },
+		]);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toBe(2);
+		}
+		expect(updateChain.update).toHaveBeenCalledTimes(2);
 	});
 });

--- a/app/_actions/ai-classify-actions.ts
+++ b/app/_actions/ai-classify-actions.ts
@@ -13,6 +13,7 @@ const CONFIDENCE_SCORE: Record<string, number> = {
 	HIGH: 0.9,
 	MEDIUM: 0.6,
 	LOW: 0.3,
+	MANUAL: 1.0,
 };
 
 export interface AiClassificationRow {
@@ -27,6 +28,7 @@ export interface AiClassificationRow {
 
 export async function runAiClassification(
 	ids: string[],
+	userInstruction?: string,
 ): Promise<ApiResponse<AiClassificationRow[]>> {
 	try {
 		const authResult = await requireAuth();
@@ -63,7 +65,7 @@ export async function runAiClassification(
 			amount: tx.amount,
 		}));
 
-		const classifyResult = await classifyTransactions(inputs);
+		const classifyResult = await classifyTransactions(inputs, userInstruction);
 		if (!classifyResult.success) {
 			return {
 				success: false,
@@ -111,26 +113,28 @@ export async function applyAiClassifications(
 		}
 
 		const supabase = await createClient();
-		let updatedCount = 0;
 
-		for (const item of parsed.data.classifications) {
-			const score = CONFIDENCE_SCORE[item.confidence] ?? 0;
-			const { error: updateError } = await supabase
-				.from("transactions")
-				.update({
-					debit_account: item.debitAccount,
-					credit_account: item.creditAccount,
-					ai_suggested: true,
-					ai_confidence: score,
-					is_confirmed: true,
-				})
-				.eq("id", item.id);
-			if (updateError) return handleApiError(updateError);
-			updatedCount++;
-		}
+		const results = await Promise.all(
+			parsed.data.classifications.map((item) => {
+				const score = CONFIDENCE_SCORE[item.confidence] ?? 0;
+				return supabase
+					.from("transactions")
+					.update({
+						debit_account: item.debitAccount,
+						credit_account: item.creditAccount,
+						ai_suggested: item.confidence !== "MANUAL",
+						ai_confidence: score,
+						is_confirmed: true,
+					})
+					.eq("id", item.id);
+			}),
+		);
+
+		const firstError = results.find((r) => r.error);
+		if (firstError?.error) return handleApiError(firstError.error);
 
 		revalidatePath("/transactions");
-		return { success: true, data: updatedCount };
+		return { success: true, data: results.length };
 	} catch (error) {
 		return handleApiError(error);
 	}

--- a/components/ai-classify-dialog.tsx
+++ b/components/ai-classify-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { Sparkles } from "lucide-react";
+import { useEffect, useState } from "react";
 import type { AiClassificationRow } from "@/app/_actions/ai-classify-actions";
 import { ACCOUNT_CATEGORIES } from "@/lib/utils/constants";
 import { Badge } from "./ui/badge";
@@ -23,6 +24,7 @@ import {
 	SelectValue,
 } from "./ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./ui/table";
+import { Textarea } from "./ui/textarea";
 
 const ACCOUNT_TYPE_LABELS: Record<string, string> = {
 	expense: "経費",
@@ -31,14 +33,17 @@ const ACCOUNT_TYPE_LABELS: Record<string, string> = {
 	liability: "負債",
 };
 
+type Confidence = "HIGH" | "MEDIUM" | "LOW" | "MANUAL";
+
 interface EditableRow {
 	id: string;
 	debitAccount: string;
 	creditAccount: string;
-	confidence: "HIGH" | "MEDIUM" | "LOW";
+	confidence: Confidence;
 }
 
-function ConfidenceBadge({ confidence }: { confidence: "HIGH" | "MEDIUM" | "LOW" }) {
+function ConfidenceBadge({ confidence }: { confidence: Confidence }) {
+	if (confidence === "MANUAL") return <Badge className="bg-blue-600 text-white">MANUAL</Badge>;
 	if (confidence === "HIGH") return <Badge className="bg-green-600 text-white">HIGH</Badge>;
 	if (confidence === "MEDIUM") return <Badge className="bg-yellow-500 text-white">MEDIUM</Badge>;
 	return <Badge className="bg-red-500 text-white">LOW</Badge>;
@@ -79,14 +84,24 @@ interface AiClassifyDialogProps {
 	open: boolean;
 	onClose: () => void;
 	onApply: (rows: EditableRow[]) => Promise<void>;
+	onReClassify: (instruction: string) => Promise<void>;
+	classifying?: boolean;
 }
 
-export function AiClassifyDialog({ results, open, onClose, onApply }: AiClassifyDialogProps) {
+export function AiClassifyDialog({
+	results,
+	open,
+	onClose,
+	onApply,
+	onReClassify,
+	classifying,
+}: AiClassifyDialogProps) {
 	const [editable, setEditable] = useState<EditableRow[]>([]);
 	const [applying, setApplying] = useState(false);
+	const [instruction, setInstruction] = useState("");
 
-	function handleOpenChange(isOpen: boolean) {
-		if (isOpen && results) {
+	useEffect(() => {
+		if (results) {
 			setEditable(
 				results.map((r) => ({
 					id: r.id,
@@ -96,11 +111,21 @@ export function AiClassifyDialog({ results, open, onClose, onApply }: AiClassify
 				})),
 			);
 		}
-		if (!isOpen) onClose();
+	}, [results]);
+
+	function handleOpenChange(isOpen: boolean) {
+		if (!isOpen) {
+			setInstruction("");
+			onClose();
+		}
 	}
 
 	function updateRow(index: number, field: "debitAccount" | "creditAccount", value: string) {
-		setEditable((prev) => prev.map((row, i) => (i === index ? { ...row, [field]: value } : row)));
+		setEditable((prev) =>
+			prev.map((row, i) =>
+				i === index ? { ...row, [field]: value, confidence: "MANUAL" as const } : row,
+			),
+		);
 	}
 
 	async function handleApply() {
@@ -109,7 +134,13 @@ export function AiClassifyDialog({ results, open, onClose, onApply }: AiClassify
 		setApplying(false);
 	}
 
+	async function handleReClassify() {
+		await onReClassify(instruction);
+	}
+
 	if (!results) return null;
+
+	const busy = applying || !!classifying;
 
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
@@ -120,6 +151,25 @@ export function AiClassifyDialog({ results, open, onClose, onApply }: AiClassify
 						{results.length}件の推定結果を確認してください。科目は変更可能です。
 					</DialogDescription>
 				</DialogHeader>
+				<div className="flex items-end gap-2">
+					<Textarea
+						placeholder="指示を入力（例: AWSの利用料は通信費にしてください）"
+						value={instruction}
+						onChange={(e) => setInstruction(e.target.value)}
+						rows={2}
+						className="flex-1"
+						disabled={busy}
+					/>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={handleReClassify}
+						disabled={busy || !instruction.trim()}
+					>
+						<Sparkles className="mr-1 size-4" />
+						{classifying ? "推定中…" : "再推定"}
+					</Button>
+				</div>
 				<div className="rounded-lg border">
 					<Table>
 						<TableHeader>
@@ -154,7 +204,7 @@ export function AiClassifyDialog({ results, open, onClose, onApply }: AiClassify
 										/>
 									</TableCell>
 									<TableCell>
-										<ConfidenceBadge confidence={row.confidence} />
+										<ConfidenceBadge confidence={editable[i]?.confidence ?? row.confidence} />
 									</TableCell>
 									<TableCell
 										className="max-w-[150px] truncate text-sm text-muted-foreground"
@@ -168,10 +218,10 @@ export function AiClassifyDialog({ results, open, onClose, onApply }: AiClassify
 					</Table>
 				</div>
 				<DialogFooter>
-					<Button variant="outline" onClick={onClose} disabled={applying}>
+					<Button variant="outline" onClick={onClose} disabled={busy}>
 						キャンセル
 					</Button>
-					<Button onClick={handleApply} disabled={applying}>
+					<Button onClick={handleApply} disabled={busy}>
 						{applying ? "適用中…" : `${results.length}件を承認`}
 					</Button>
 				</DialogFooter>

--- a/components/transaction-list-actions.tsx
+++ b/components/transaction-list-actions.tsx
@@ -125,6 +125,17 @@ export function TransactionListActions({ transactions }: TransactionListActionsP
 		}
 	}
 
+	async function handleReClassify(instruction: string) {
+		setLoading(true);
+		const result = await runAiClassification([...selected], instruction);
+		setLoading(false);
+		if (result.success) {
+			setClassifyResults(result.data);
+		} else {
+			toast({ title: "AI推定に失敗しました", description: result.error, variant: "destructive" });
+		}
+	}
+
 	async function handleApplyClassifications(
 		rows: { id: string; debitAccount: string; creditAccount: string; confidence: string }[],
 	) {
@@ -268,6 +279,8 @@ export function TransactionListActions({ transactions }: TransactionListActionsP
 				open={classifyResults !== null}
 				onClose={() => setClassifyResults(null)}
 				onApply={handleApplyClassifications}
+				onReClassify={handleReClassify}
+				classifying={loading}
 			/>
 		</>
 	);

--- a/lib/claude/__tests__/client.test.ts
+++ b/lib/claude/__tests__/client.test.ts
@@ -214,6 +214,40 @@ describe("classifyTransactions", () => {
 		}
 	});
 
+	it("ユーザー指示がプロンプトに含まれる", async () => {
+		mockCreate.mockResolvedValue(validApiResponse);
+
+		await classifyTransactions(sampleInput, "AWSは通信費にしてください");
+
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				messages: expect.arrayContaining([
+					expect.objectContaining({
+						role: "user",
+						content: expect.stringContaining("AWSは通信費にしてください"),
+					}),
+				]),
+			}),
+		);
+	});
+
+	it("ユーザー指示なしで従来通り動作する", async () => {
+		mockCreate.mockResolvedValue(validApiResponse);
+
+		await classifyTransactions(sampleInput);
+
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				messages: expect.arrayContaining([
+					expect.objectContaining({
+						role: "user",
+						content: expect.not.stringContaining("ユーザー指示"),
+					}),
+				]),
+			}),
+		);
+	});
+
 	it("エラー詳細を漏洩しない", async () => {
 		mockCreate.mockRejectedValue(new Error("secret internal error details"));
 

--- a/lib/claude/client.ts
+++ b/lib/claude/client.ts
@@ -11,6 +11,7 @@ import {
 
 export async function classifyTransactions(
 	transactions: TransactionInput[],
+	userInstruction?: string,
 ): Promise<ApiResponse<ClassifiedTransaction[]>> {
 	try {
 		const parsed = aiClassifyRequestSchema.safeParse({ transactions });
@@ -24,7 +25,7 @@ export async function classifyTransactions(
 			max_tokens: 4096,
 			system: SYSTEM_PROMPT,
 			messages: [
-				{ role: "user", content: buildUserPrompt(parsed.data.transactions) },
+				{ role: "user", content: buildUserPrompt(parsed.data.transactions, userInstruction) },
 				{ role: "assistant", content: "{" },
 			],
 		});

--- a/lib/claude/prompts.ts
+++ b/lib/claude/prompts.ts
@@ -23,12 +23,19 @@ ${accountList}
 以下のJSON形式のみを返してください。説明文やマークダウンは不要です。
 {"classifications":[{"id":"取引ID","debitAccount":"借方コード","creditAccount":"貸方コード","confidence":"HIGH","reason":"理由"}]}`;
 
-export function buildUserPrompt(transactions: TransactionInput[]): string {
+export function buildUserPrompt(
+	transactions: TransactionInput[],
+	userInstruction?: string,
+): string {
 	const items = transactions
 		.map(
 			(tx, i) => `${i + 1}. [${tx.id ?? "no-id"}] ${tx.date} | ${tx.description} | ${tx.amount}円`,
 		)
 		.join("\n");
 
-	return `以下の取引の仕訳を推定してください:\n\n${items}`;
+	let prompt = `以下の取引の仕訳を推定してください:\n\n${items}`;
+	if (userInstruction?.trim()) {
+		prompt += `\n\n## ユーザー指示\n${userInstruction.trim()}`;
+	}
+	return prompt;
 }

--- a/lib/validators/transaction.ts
+++ b/lib/validators/transaction.ts
@@ -90,7 +90,7 @@ export const applyClassificationsSchema = z.object({
 				id: z.string().uuid("無効なIDです"),
 				debitAccount: accountCodeSchema,
 				creditAccount: accountCodeSchema,
-				confidence: z.enum(["HIGH", "MEDIUM", "LOW"]),
+				confidence: z.enum(["HIGH", "MEDIUM", "LOW", "MANUAL"]),
 			}),
 		)
 		.min(1, "1件以上の分類を指定してください")


### PR DESCRIPTION
## Summary
- AI推定ダイアログに自然言語指示 Textarea + 「再推定」ボタンを追加
- `applyAiClassifications` をバッチ更新（`Promise.all`）に改善
- ユーザーが科目を変更した場合、confidence を `MANUAL`（青バッジ, score=1.0）に自動変更
- `ai_suggested` を MANUAL 時 `false` に設定（手動選択は AI 提案ではない）

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `lib/claude/prompts.ts` | `buildUserPrompt` に `userInstruction` パラメータ追加 |
| `lib/claude/client.ts` | `classifyTransactions` に `userInstruction` 透過 |
| `lib/claude/__tests__/client.test.ts` | 指示テスト 2件追加（計12件） |
| `lib/validators/transaction.ts` | confidence enum に `"MANUAL"` 追加 |
| `app/_actions/ai-classify-actions.ts` | MANUAL score, `Promise.all` バッチ, `userInstruction` 引数 |
| `app/_actions/__tests__/ai-classify-actions.test.ts` | MANUAL, batch, instruction テスト 3件追加（計17件） |
| `components/ai-classify-dialog.tsx` | Textarea, MANUAL バッジ, `onReClassify`, `useEffect` 同期 |
| `components/transaction-list-actions.tsx` | `handleReClassify` コールバック追加 |

## Test plan
- [x] 全127テスト PASS
- [x] TypeScript 型エラー 0件
- [x] Biome lint エラー 0件
- [x] カバレッジ: Statements 91.36% / Branches 85.94% / Functions 97.61% / Lines 92.1%
- [ ] 手動確認: AI推定 → モーダル → 科目変更 → MANUAL バッジ表示 → 指示入力 → 再推定 → 承認

## Note
Issue #47 Phase 2 は 2 PR に分割:
- **PR A（本PR）**: レビュー修正 + 自然言語指示（永続化なし）
- **PR B（次PR）**: 指示履歴の永続化（DB + CRUD + UI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)