### PR TITLE
fix: AI推定ルール保存の失敗を修正

### DIFF
--- a/components/__tests__/ai-classify-dialog.test.tsx
+++ b/components/__tests__/ai-classify-dialog.test.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({
+	useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/app/_actions/classification-rule-actions", () => ({
+	saveClassificationRule: vi.fn(),
+	getClassificationRules: vi.fn(),
+	deleteClassificationRule: vi.fn(),
+}));
+
+import type { AiClassificationRow } from "@/app/_actions/ai-classify-actions";
+import {
+	deleteClassificationRule,
+	getClassificationRules,
+	saveClassificationRule,
+} from "@/app/_actions/classification-rule-actions";
+import { AiClassifyDialog } from "../ai-classify-dialog";
+
+const mockSave = vi.mocked(saveClassificationRule);
+const mockGet = vi.mocked(getClassificationRules);
+const mockDelete = vi.mocked(deleteClassificationRule);
+
+const sampleResults: AiClassificationRow[] = [
+	{
+		id: "tx-1",
+		description: "AWS利用料",
+		amount: 10000,
+		debitAccount: "expense_communication",
+		creditAccount: "liability_credit_card",
+		confidence: "HIGH",
+		reason: "クラウドサービス利用",
+	},
+];
+
+function renderDialog(overrides = {}) {
+	const defaultProps = {
+		results: sampleResults,
+		open: true,
+		onClose: vi.fn(),
+		onApply: vi.fn().mockResolvedValue(undefined),
+		onReClassify: vi.fn().mockResolvedValue(undefined),
+	};
+	return render(<AiClassifyDialog {...defaultProps} {...overrides} />);
+}
+
+describe("AiClassifyDialog ルール保存エラーハンドリング", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGet.mockResolvedValue({ success: true, data: [] });
+	});
+
+	it("保存失敗時にエラーメッセージをtoast descriptionに表示する", async () => {
+		mockSave.mockResolvedValue({
+			success: false,
+			error: "ルールは最大20件までです。",
+			code: "VALIDATION_ERROR",
+		});
+
+		renderDialog();
+
+		const textarea = screen.getByPlaceholderText(/指示を入力/);
+		fireEvent.change(textarea, { target: { value: "テストルール" } });
+
+		const saveButton = screen.getByRole("button", { name: /保存/ });
+		fireEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(mockToast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: "ルールの保存に失敗しました",
+					description: "ルールは最大20件までです。",
+					variant: "destructive",
+				}),
+			);
+		});
+	});
+
+	it("保存中にサーバーアクションがthrowした場合にエラーtoastを表示する", async () => {
+		mockSave.mockRejectedValue(new Error("Network Error"));
+
+		renderDialog();
+
+		const textarea = screen.getByPlaceholderText(/指示を入力/);
+		fireEvent.change(textarea, { target: { value: "テストルール" } });
+
+		const saveButton = screen.getByRole("button", { name: /保存/ });
+		fireEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(mockToast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: "ルールの保存に失敗しました",
+					variant: "destructive",
+				}),
+			);
+		});
+	});
+
+	it("削除失敗時にエラーメッセージをtoast descriptionに表示する", async () => {
+		const ruleId = "550e8400-e29b-41d4-a716-446655440000";
+		mockGet.mockResolvedValue({
+			success: true,
+			data: [{ id: ruleId, instruction: "既存ルール", created_at: "2026-03-01T00:00:00Z" }],
+		});
+		mockDelete.mockResolvedValue({
+			success: false,
+			error: "削除権限がありません。",
+			code: "FORBIDDEN",
+		});
+
+		renderDialog();
+
+		await waitFor(() => {
+			expect(screen.getByText("既存ルール")).toBeInTheDocument();
+		});
+
+		const deleteButtons = screen.getAllByRole("button").filter((btn) => {
+			return btn.querySelector("svg.lucide-x") !== null;
+		});
+		expect(deleteButtons.length).toBeGreaterThan(0);
+		fireEvent.click(deleteButtons[0]);
+
+		await waitFor(() => {
+			expect(mockToast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: "ルールの削除に失敗しました",
+					description: "削除権限がありません。",
+					variant: "destructive",
+				}),
+			);
+		});
+	});
+
+	it("削除中にサーバーアクションがthrowした場合にエラーtoastを表示する", async () => {
+		const ruleId = "550e8400-e29b-41d4-a716-446655440000";
+		mockGet.mockResolvedValue({
+			success: true,
+			data: [{ id: ruleId, instruction: "既存ルール", created_at: "2026-03-01T00:00:00Z" }],
+		});
+		mockDelete.mockRejectedValue(new Error("Network Error"));
+
+		renderDialog();
+
+		await waitFor(() => {
+			expect(screen.getByText("既存ルール")).toBeInTheDocument();
+		});
+
+		const deleteButtons = screen.getAllByRole("button").filter((btn) => {
+			return btn.querySelector("svg.lucide-x") !== null;
+		});
+		fireEvent.click(deleteButtons[0]);
+
+		await waitFor(() => {
+			expect(mockToast).toHaveBeenCalledWith(
+				expect.objectContaining({
+					title: "ルールの削除に失敗しました",
+					variant: "destructive",
+				}),
+			);
+		});
+	});
+});

--- a/components/ai-classify-dialog.tsx
+++ b/components/ai-classify-dialog.tsx
@@ -161,20 +161,36 @@ export function AiClassifyDialog({
 
 	async function handleSaveRule() {
 		if (!instruction.trim()) return;
-		const result = await saveClassificationRule(instruction.trim());
-		if (result.success) {
-			setRules((prev) => [result.data, ...prev]);
-			toast({ title: "ルールを保存しました" });
-		} else {
+		try {
+			const result = await saveClassificationRule(instruction.trim());
+			if (result.success) {
+				setRules((prev) => [result.data, ...prev]);
+				toast({ title: "ルールを保存しました" });
+			} else {
+				toast({
+					title: "ルールの保存に失敗しました",
+					description: result.error,
+					variant: "destructive",
+				});
+			}
+		} catch {
 			toast({ title: "ルールの保存に失敗しました", variant: "destructive" });
 		}
 	}
 
 	async function handleDeleteRule(id: string) {
-		const result = await deleteClassificationRule(id);
-		if (result.success) {
-			setRules((prev) => prev.filter((r) => r.id !== id));
-		} else {
+		try {
+			const result = await deleteClassificationRule(id);
+			if (result.success) {
+				setRules((prev) => prev.filter((r) => r.id !== id));
+			} else {
+				toast({
+					title: "ルールの削除に失敗しました",
+					description: result.error,
+					variant: "destructive",
+				});
+			}
+		} catch {
 			toast({ title: "ルールの削除に失敗しました", variant: "destructive" });
 		}
 	}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
 			"lib/**/__tests__/**/*.test.tsx",
 			"app/**/__tests__/**/*.test.ts",
 			"app/**/__tests__/**/*.test.tsx",
+			"components/**/__tests__/**/*.test.ts",
+			"components/**/__tests__/**/*.test.tsx",
 			"tests/unit/**/*.test.ts",
 			"tests/integration/**/*.test.ts",
 		],


### PR DESCRIPTION
## Summary

- `handleSaveRule` / `handleDeleteRule` に try-catch を追加し、サーバーアクションが例外をthrowした場合もエラーtoastを表示するように修正
- toast の `description` に `result.error` を含めて、具体的なエラー原因（例: 上限20件超過）をユーザーに表示
- `vitest.config.ts` に `components/**/__tests__/` パスを追加
- コンポーネントテスト4件追加（保存/削除のエラー応答 + 例外throw）

## Test plan

- [x] `npm run test:unit` — 全181件 PASS
- [x] `npx tsc --noEmit` — 型エラー 0件
- [x] `npx biome check` — エラー 0件
- [ ] 手動: AI推定ダイアログでルール保存→エラー時にtoastにエラー詳細が表示されること
- [ ] 手動: ルール削除失敗時にtoastにエラー詳細が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)