### PR TITLE
feat: ダッシュボード月次サマリー + 科目別集計 (Issue #18)

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -57,7 +57,6 @@ export default async function DashboardPage(props: { searchParams: Promise<{ mon
 
 	const { income, expense, balance, expenseBreakdown, unconfirmedCount, recentImports } =
 		result.data;
-	const totalExpense = expense || 1;
 
 	return (
 		<div className="flex flex-col gap-6 p-4 md:p-6">
@@ -124,7 +123,7 @@ export default async function DashboardPage(props: { searchParams: Promise<{ mon
 						) : (
 							<div className="space-y-3">
 								{expenseBreakdown.map((item) => {
-									const ratio = Math.round((item.amount / totalExpense) * 100);
+									const ratio = expense > 0 ? Math.round((item.amount / expense) * 100) : 0;
 									return (
 										<div key={item.code} className="flex items-center gap-3">
 											<span className="w-24 text-sm truncate">{item.name}</span>

--- a/app/_actions/__tests__/dashboard-actions.test.ts
+++ b/app/_actions/__tests__/dashboard-actions.test.ts
@@ -56,14 +56,14 @@ function createSupabaseMock(
 	},
 ) {
 	const transactionsMock: Record<string, ReturnType<typeof vi.fn>> = {};
-	for (const method of ["select", "gte", "lte", "is"]) {
+	for (const method of ["select", "eq", "gte", "lte", "is"]) {
 		transactionsMock[method] = vi.fn().mockReturnValue(transactionsMock);
 	}
 	// Final method in chain resolves the result
 	transactionsMock.is = vi.fn().mockResolvedValue(transactionsResult);
 
 	const importLogsMock: Record<string, ReturnType<typeof vi.fn>> = {};
-	for (const method of ["select", "order"]) {
+	for (const method of ["select", "eq", "order"]) {
 		importLogsMock[method] = vi.fn().mockReturnValue(importLogsMock);
 	}
 	importLogsMock.limit = vi.fn().mockResolvedValue(importLogsResult);
@@ -206,6 +206,16 @@ describe("getDashboardData", () => {
 		expect(result.success).toBe(false);
 		if (result.success) return;
 		expect(result.code).toBe("UNAUTHORIZED");
+	});
+
+	it("不正な月フォーマットでVALIDATION_ERRORを返す", async () => {
+		mockAuthSuccess();
+
+		const result = await getDashboardData({ month: "invalid" });
+
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.code).toBe("VALIDATION_ERROR");
 	});
 
 	it("取引0件の場合、全て0/空配列を返す", async () => {

--- a/app/_actions/dashboard-actions.ts
+++ b/app/_actions/dashboard-actions.ts
@@ -1,11 +1,16 @@
 "use server";
 
 import { endOfMonth, parse, startOfMonth } from "date-fns";
+import { z } from "zod";
 import { handleApiError } from "@/lib/api/error";
 import { requireAuth } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import type { ApiResponse } from "@/lib/types/api";
 import { ACCOUNT_CATEGORIES } from "@/lib/utils/constants";
+
+const dashboardParamsSchema = z.object({
+	month: z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/, "月はYYYY-MM形式で入力してください"),
+});
 
 type DashboardData = {
 	month: string;
@@ -34,14 +39,25 @@ export async function getDashboardData(params: {
 		const authResult = await requireAuth();
 		if (!authResult.success) return authResult;
 
+		const parsed = dashboardParamsSchema.safeParse(params);
+		if (!parsed.success) {
+			return {
+				success: false,
+				error: "月はYYYY-MM形式で入力してください。",
+				code: "VALIDATION_ERROR",
+			};
+		}
+
 		const supabase = await createClient();
-		const monthDate = parse(params.month, "yyyy-MM", new Date());
+		const userId = authResult.data.id;
+		const monthDate = parse(parsed.data.month, "yyyy-MM", new Date());
 		const monthStart = startOfMonth(monthDate).toISOString().split("T")[0];
 		const monthEnd = endOfMonth(monthDate).toISOString().split("T")[0];
 
 		const { data: transactions, error: txError } = await supabase
 			.from("transactions")
 			.select("amount, debit_account, credit_account, is_confirmed")
+			.eq("user_id", userId)
 			.gte("transaction_date", monthStart)
 			.lte("transaction_date", monthEnd)
 			.is("deleted_at", null);
@@ -80,6 +96,7 @@ export async function getDashboardData(params: {
 		const { data: importLogs, error: importError } = await supabase
 			.from("import_logs")
 			.select("id, file_name, status, row_count, created_at")
+			.eq("user_id", userId)
 			.order("created_at", { ascending: false })
 			.limit(5);
 
@@ -96,7 +113,7 @@ export async function getDashboardData(params: {
 		return {
 			success: true,
 			data: {
-				month: params.month,
+				month: parsed.data.month,
 				income,
 				expense,
 				balance: income - expense,


### PR DESCRIPTION
## Summary

- `getDashboardData` Server Action を新規作成: 月次の収入/支出/差額、科目別経費内訳、未確認取引件数、直近インポート履歴を集計
- ダッシュボードページを4セクション構成に置き換え: 月次サマリーカード、科目別内訳バー、未確認取引バッジ、直近インポートテーブル
- 月切り替えは `?month=YYYY-MM` searchParams + `<Link>` で Server Component のまま実現

Closes #18

## 変更内容

| ファイル | 操作 | 説明 |
|---------|------|------|
| `app/_actions/dashboard-actions.ts` | 新規 | getDashboardData Server Action |
| `app/_actions/__tests__/dashboard-actions.test.ts` | 新規 | 6テストケース (TDD) |
| `app/(app)/dashboard/page.tsx` | 修正 | プレースホルダー → 4セクション UI |

## PR サイズ

- 3ファイル, 542 insertions（うちテスト226行）
- 実装のみ: 316行（300行ガイドラインを若干超過するが、単一機能で分割不適切）

## Test plan

- [x] `npm run test:unit` — 全256テスト通過（新規6テスト含む）
- [x] `npm run lint` — Biome lint エラー 0
- [x] `npx tsc --noEmit` — 型エラー 0
- [x] `npm run build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)