### PR TITLE
fix: Revolut CSV 日本語ヘッダー対応 (Issue #66)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ npm-debug.log*
 supabase/.temp/
 .claude/settings.local.json
 .vercel
+tmp/

--- a/lib/csv/parsers.ts
+++ b/lib/csv/parsers.ts
@@ -45,9 +45,8 @@ export const wiseRowSchema = z.object({
 });
 
 /**
- * Revolut CSV カラム定義
+ * Revolut CSV カラム定義（英語版）
  * columns: Date, Description, Amount, Currency, Balance
- * Note: UTC/ローカル時刻の両方が含まれる場合あり
  */
 export const revolutRowSchema = z.object({
 	Date: z.string().min(1),
@@ -55,6 +54,20 @@ export const revolutRowSchema = z.object({
 	Amount: z.string().min(1),
 	Currency: z.string().min(1),
 	Balance: z.string().optional(),
+});
+
+/**
+ * Revolut CSV カラム定義（日本語版）
+ * columns: 種類, サービス, 開始日, 完了日, お取引, 金額, 手数料, 通貨, 状態, 残高
+ */
+export const revolutRowSchemaJa = z.object({
+	開始日: z.string().min(1),
+	お取引: z.string().min(1),
+	金額: z.string().min(1),
+	通貨: z.string().min(1),
+	残高: z.string().optional(),
+	状態: z.string().optional(),
+	手数料: z.string().optional(),
 });
 
 /**
@@ -81,7 +94,16 @@ export function detectCsvFormat(headers: string[]): CsvFormat {
 		return "rakuten";
 	}
 
-	// Revolut: Date, Description, Amount, Currency, Balance の組み合わせ
+	// Revolut（日本語版）: お取引, 金額, 通貨 の組み合わせ
+	if (
+		headers.some((h) => h.trim() === "お取引") &&
+		headers.some((h) => h.trim() === "金額") &&
+		headers.some((h) => h.trim() === "通貨")
+	) {
+		return "revolut";
+	}
+
+	// Revolut（英語版）: Date, Description, Amount, Currency, Balance の組み合わせ
 	if (
 		normalized.includes("date") &&
 		normalized.includes("description") &&
@@ -321,12 +343,14 @@ export function parseWiseCsv(csvText: string): ParsedTransaction[] {
 
 /**
  * Revolut CSVをパースして統一取引データに変換
+ * 英語版・日本語版の両方に対応
  */
 export function parseRevolutCsv(csvText: string): ParsedTransaction[] {
 	const lines = csvText.split(/\r?\n/).filter((line) => line.trim() !== "");
 	if (lines.length < 2) return [];
 
 	const headers = splitCsvLine(lines[0]);
+	const isJapanese = headers.some((h) => h.trim() === "お取引");
 	const transactions: ParsedTransaction[] = [];
 
 	for (let i = 1; i < lines.length; i++) {
@@ -336,19 +360,37 @@ export function parseRevolutCsv(csvText: string): ParsedTransaction[] {
 			row[headers[j]] = columns[j] ?? "";
 		}
 
-		const parsed = revolutRowSchema.safeParse(row);
-		if (!parsed.success) continue;
-
-		const data = parsed.data;
-		try {
-			transactions.push({
-				date: normalizeDate(data.Date),
-				description: data.Description,
-				amount: parseAmount(data.Amount),
-				originalCurrency: data.Currency,
-			});
-		} catch {
-			// 金額パースエラー時はスキップ
+		if (isJapanese) {
+			const parsed = revolutRowSchemaJa.safeParse(row);
+			if (!parsed.success) continue;
+			const data = parsed.data;
+			if (data.状態 && data.状態 !== "完了済み") continue;
+			try {
+				const fees = data.手数料 ? parseAmount(data.手数料) : 0;
+				transactions.push({
+					date: normalizeDate(data.開始日),
+					description: data.お取引,
+					amount: parseAmount(data.金額),
+					originalCurrency: data.通貨,
+					fees: fees !== 0 ? fees : undefined,
+				});
+			} catch {
+				// 金額パースエラー時はスキップ
+			}
+		} else {
+			const parsed = revolutRowSchema.safeParse(row);
+			if (!parsed.success) continue;
+			const data = parsed.data;
+			try {
+				transactions.push({
+					date: normalizeDate(data.Date),
+					description: data.Description,
+					amount: parseAmount(data.Amount),
+					originalCurrency: data.Currency,
+				});
+			} catch {
+				// 金額パースエラー時はスキップ
+			}
 		}
 	}
 

--- a/tests/unit/lib/__tests__/csv-parsers.test.ts
+++ b/tests/unit/lib/__tests__/csv-parsers.test.ts
@@ -38,6 +38,22 @@ describe("CSV パーサー", () => {
 			const headers = ["date", "description", "amount", "currency", "balance"];
 			expect(detectCsvFormat(headers)).toBe("revolut");
 		});
+
+		it("日本語版 Revolut ヘッダーを検出する", () => {
+			const headers = [
+				"種類",
+				"サービス",
+				"開始日",
+				"完了日",
+				"お取引",
+				"金額",
+				"手数料",
+				"通貨",
+				"状態",
+				"残高",
+			];
+			expect(detectCsvFormat(headers)).toBe("revolut");
+		});
 	});
 
 	describe("normalizeDate", () => {
@@ -341,6 +357,50 @@ describe("CSV パーサー", () => {
 		});
 	});
 
+	describe("parseRevolutCsv（日本語版）", () => {
+		const revolutJaCsv = [
+			"種類,サービス,開始日,完了日,お取引,金額,手数料,通貨,状態,残高",
+			"カード支払い,当座,2025-01-01 05:07:13,2025-01-02 22:11:53,Emart K.w Sepang,-1751,0,JPY,完了済み,109592",
+			"チャージ,当座,2025-01-03 12:45:36,2025-01-03 12:47:46,*9092によるチャージ,100000,0,JPY,完了済み,198171",
+		].join("\n");
+
+		it("日本語版CSVをパースして取引一覧を返す", () => {
+			const result = parseRevolutCsv(revolutJaCsv);
+			expect(result).toHaveLength(2);
+			expect(result[0].description).toBe("Emart K.w Sepang");
+			expect(result[0].amount).toBe(-1751);
+			expect(result[0].originalCurrency).toBe("JPY");
+		});
+
+		it("日付（YYYY-MM-DD HH:MM:SS）をYYYY-MM-DDに正規化する", () => {
+			const result = parseRevolutCsv(revolutJaCsv);
+			expect(result[0].date).toBe("2025-01-01");
+			expect(result[1].date).toBe("2025-01-03");
+		});
+
+		it("「差し戻された」ステータスの行をスキップする", () => {
+			const csvWithReverted = [
+				"種類,サービス,開始日,完了日,お取引,金額,手数料,通貨,状態,残高",
+				"カード支払い,当座,2025-01-02 14:19:47,,Grab,-36,0,JPY,差し戻された,",
+				"カード支払い,当座,2025-01-01 05:07:13,2025-01-02 22:11:53,Emart,-1751,0,JPY,完了済み,109592",
+			].join("\n");
+			const result = parseRevolutCsv(csvWithReverted);
+			expect(result).toHaveLength(1);
+			expect(result[0].description).toBe("Emart");
+		});
+
+		it("手数料が0以外の場合feesにマッピングする", () => {
+			const csvWithFees = [
+				"種類,サービス,開始日,完了日,お取引,金額,手数料,通貨,状態,残高",
+				"カード支払い,当座,2025-01-01 05:07:13,2025-01-02 22:11:53,Transfer,-5000,150,JPY,完了済み,100000",
+				"カード支払い,当座,2025-01-01 06:00:00,2025-01-02 22:11:53,Netflix,-1500,0,JPY,完了済み,98500",
+			].join("\n");
+			const result = parseRevolutCsv(csvWithFees);
+			expect(result[0].fees).toBe(150);
+			expect(result[1].fees).toBeUndefined();
+		});
+	});
+
 	describe("parseGenericCsv", () => {
 		const genericCsv = [
 			"date,description,amount",
@@ -411,6 +471,16 @@ describe("CSV パーサー", () => {
 			const result = parseCsv("");
 			expect(result.format).toBe("generic");
 			expect(result.transactions).toEqual([]);
+		});
+
+		it("日本語版 Revolut CSVを自動判定してパースする", () => {
+			const revolutJaCsv = [
+				"種類,サービス,開始日,完了日,お取引,金額,手数料,通貨,状態,残高",
+				"カード支払い,当座,2025-01-01 05:07:13,2025-01-02 22:11:53,Netflix,-1500,0,JPY,完了済み,48500",
+			].join("\n");
+			const result = parseCsv(revolutJaCsv);
+			expect(result.format).toBe("revolut");
+			expect(result.transactions).toHaveLength(1);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Revolut の日本語版 CSV（ヘッダー: 種類,サービス,開始日,完了日,お取引,金額,手数料,通貨,状態,残高）のパースに対応
- `detectCsvFormat` に日本語ヘッダー検出を追加
- `parseRevolutCsv` でヘッダー言語を自動判定し、適切なスキーマでパース
- 「差し戻された」ステータスの行をスキップ（完了済みのみインポート）

Closes #66

## 変更内容

| ファイル | 操作 | 説明 |
|---------|------|------|
| `lib/csv/parsers.ts` | 修正 | revolutRowSchemaJa追加、detectCsvFormat/parseRevolutCsv修正 |
| `tests/unit/lib/__tests__/csv-parsers.test.ts` | 修正 | 6テストケース追加（計61テスト） |
| `.gitignore` | 修正 | tmp/ 追加 |

## PR サイズ

3ファイル, 129 insertions — PR制限内

## Test plan

- [x] `npm run test:unit` — 全263テスト通過（新規6テスト含む）
- [x] `npm run lint` — Biome lint エラー 0
- [x] `npx tsc --noEmit` — 型エラー 0
- [x] `npm run build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)