### PR TITLE
fix: ログイン画面の入力フィールド視認性修正 (Issue #68)

### DIFF
--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
 			type={type}
 			data-slot="input"
 			className={cn(
-				"file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+				"text-foreground file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
 				"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
 				"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
 				className,


### PR DESCRIPTION
## Summary

- Input コンポーネントに `text-foreground` を明示的に追加し、テキスト色がテーマに応じて正しく適用されるよう修正
- ライトモード・ダークモード両方で入力文字が視認可能に

Closes #68

## 変更内容

| ファイル | 操作 | 説明 |
|---------|------|------|
| `components/ui/input.tsx` | 修正 | className に `text-foreground` を追加（1行変更） |

## 原因

Input コンポーネントに明示的なテキスト色指定がなく、`bg-transparent` + ブラウザデフォルトの `color` 継承に依存していたため、テーマやブラウザ設定によってテキストと背景のコントラストが不足していた。

## Test plan

- [x] `npx tsc --noEmit` — 型エラー 0
- [x] `npm run lint` — Biome lint エラー 0
- [x] `npm run test:unit` — 全263テスト通過
- [x] `npm run build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)