### PR TITLE
fix: CSVインポート上限を1000件から2500件に引き上げ

### DIFF
--- a/app/_actions/__tests__/import-actions.test.ts
+++ b/app/_actions/__tests__/import-actions.test.ts
@@ -135,9 +135,9 @@ describe("importTransactions", () => {
 		}
 	});
 
-	it("1001件超過でバリデーションエラーを返す", async () => {
+	it("2501件超過でバリデーションエラーを返す", async () => {
 		mockAuthSuccess();
-		const tooMany = Array.from({ length: 1001 }, (_, i) => ({
+		const tooMany = Array.from({ length: 2501 }, (_, i) => ({
 			date: "2026-01-01",
 			description: `取引${i}`,
 			amount: 100,

--- a/lib/utils/constants.ts
+++ b/lib/utils/constants.ts
@@ -49,7 +49,7 @@ export const AI_CONFIDENCE = {
 export const UPLOAD_LIMITS = {
 	MAX_FILE_SIZE: 5 * 1024 * 1024,
 	ALLOWED_CSV_TYPES: ["text/csv", "application/vnd.ms-excel"],
-	MAX_ROWS_PER_IMPORT: 1000,
+	MAX_ROWS_PER_IMPORT: 2500,
 } as const;
 
 export const RATE_LIMITS = {


### PR DESCRIPTION
## 概要

`UPLOAD_LIMITS.MAX_ROWS_PER_IMPORT` を 1000 → 2500 に変更。
Revolut CSV など2000件超のファイルをインポートできるようにする。

## 変更内容

- `lib/utils/constants.ts`: `MAX_ROWS_PER_IMPORT` を 1000 → 2500 に変更
- `app/_actions/__tests__/import-actions.test.ts`: 上限テストを 1001件 → 2501件 に更新

## テスト結果

- ✅ `npm run typecheck` — エラー 0
- ✅ `npm run lint` — エラー 0
- ✅ `npm run test:unit` — 267 tests passed
- ✅ 上限超過バリデーションテスト通過

## サイズ

- **6行変更 / 2ファイル** (制限: 300行 / 10ファイル)