### PR TITLE
ci: Lighthouse CI 導入 (Issue #74)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,3 +130,30 @@ jobs:
             exit 1
           fi
           echo "✅ No sensitive NEXT_PUBLIC_ keys found."
+
+  # ============================================
+  # Stage 6: Lighthouse CI
+  # ============================================
+  lighthouse:
+    name: Lighthouse CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+      - run: npm ci
+      - name: Build Next.js
+        run: npm run build
+      - name: Run Lighthouse CI
+        run: npx --yes @lhci/cli autorun
+      - name: Upload Lighthouse report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: .lighthouseci/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ supabase/.temp/
 .claude/settings.local.json
 .vercel
 tmp/
+.lighthouseci/

--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -1,0 +1,25 @@
+/** @type {import('@lhci/cli').UserConfig} */
+module.exports = {
+	ci: {
+		collect: {
+			startServerCommand: "npm run start",
+			startServerReadyPattern: "Ready",
+			url: ["http://localhost:3000/login"],
+			numberOfRuns: 3,
+			settings: {
+				chromeFlags: "--no-sandbox --headless",
+				skipAudits: ["uses-http2"],
+			},
+		},
+		assert: {
+			assertions: {
+				"categories:performance": ["warn", { minScore: 0.8 }],
+				"categories:accessibility": ["error", { minScore: 0.9 }],
+				"categories:best-practices": ["error", { minScore: 0.9 }],
+			},
+		},
+		upload: {
+			target: "temporary-public-storage",
+		},
+	},
+};


### PR DESCRIPTION
## 概要

GitHub Actions に Lighthouse CI を導入し、パフォーマンス・アクセシビリティを継続的に監視する。

Closes #74

## 変更内容

- `.lighthouserc.cjs`: Lighthouse CI 設定（`/login` を3回監査、スコア閾値設定）
- `.github/workflows/ci.yml`: Stage 6 として Lighthouse CI ジョブを追加
- `.gitignore`: `.lighthouseci/` ディレクトリを除外

## 設計判断

| 項目 | 判断 | 理由 |
|------|------|------|
| ターゲット URL | `/login` | 認証不要、フォーム/タブ/ラベルあり、a11y検証に最適 |
| インストール方式 | `npx --yes @lhci/cli` | CI 専用ツールのため `package.json` に追加しない |
| ビルド方式 | ジョブ内で再ビルド | `.next/` の artifact 共有は大きく脆弱 |
| スコア閾値 | Perf ≥ 0.8 (warn), A11y ≥ 0.9, BP ≥ 0.9 (error) | パフォーマンスは warn、それ以外は error で段階的に導入 |
| レポート保存 | `temporary-public-storage` + artifact (7日) | サーバー不要、無料 |

## テスト結果

- `npm run typecheck`: 0 errors
- `npm run lint` (変更ファイルのみ): 0 errors
- `npm run test:unit`: **267 tests passed** (19 files)
- サイズ: **53行 / 3ファイル** (制限: 300行 / 10ファイル)

## テスト計画

- [ ] CI の Lighthouse ジョブが PR 上で正常に実行されること
- [ ] Lighthouse レポートが artifact としてアップロードされること
- [ ] スコア閾値違反時にジョブが失敗すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)