### PR TITLE
fix: Vercel Deployment Protection bypass で E2E テスト修正

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,7 @@ jobs:
           BASE_URL: ${{ github.event.deployment_status.target_url }}
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Upload Playwright report
         if: failure()

--- a/docs/PRODUCTION_SETUP.md
+++ b/docs/PRODUCTION_SETUP.md
@@ -57,7 +57,25 @@ Vercel Dashboard > Settings > Environment Variables に以下を設定:
 2. Client ID と Client Secret を入力
 3. `app/login/page.tsx` の Google ログインボタンのコメントアウトを解除
 
-## 4. 動作確認チェックリスト
+## 4. E2E テスト用 Vercel Protection Bypass
+
+Vercel の Deployment Protection が有効な場合、CI の E2E テストが Preview デプロイにアクセスできるよう Bypass を設定する。
+
+### Vercel Dashboard
+
+1. Vercel Dashboard > Settings > Deployment Protection
+2. 「Protection Bypass for Automation」を有効化
+3. 生成された Secret をコピー
+
+### GitHub Secrets
+
+```bash
+echo "<コピーした Secret>" | gh secret set VERCEL_AUTOMATION_BYPASS_SECRET
+```
+
+Playwright が `x-vercel-protection-bypass` ヘッダーを自動付与し、Preview デプロイの認証をバイパスする。
+
+## 5. 動作確認チェックリスト
 
 - [ ] メール/パスワードでサインアップ・ログインができる
 - [ ] Google OAuth でログインができる

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,6 +31,11 @@ export default defineConfig({
 		baseURL,
 		trace: "on-first-retry",
 		screenshot: "only-on-failure",
+		...(process.env.VERCEL_AUTOMATION_BYPASS_SECRET && {
+			extraHTTPHeaders: {
+				"x-vercel-protection-bypass": process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+			},
+		}),
 	},
 	projects: [
 		{


### PR DESCRIPTION
## 概要

Vercel の Deployment Protection が有効な Preview デプロイに対して、E2E テストが 401 Unauthorized で失敗する問題を修正。
`x-vercel-protection-bypass` ヘッダーを Playwright に追加し、CI の E2E テストが認証保護をバイパスできるようにする。

## 変更内容

- `playwright.config.ts`: `VERCEL_AUTOMATION_BYPASS_SECRET` 環境変数がある場合に `extraHTTPHeaders` で `x-vercel-protection-bypass` ヘッダーを付与
- `.github/workflows/e2e.yml`: `VERCEL_AUTOMATION_BYPASS_SECRET` シークレットを環境変数として渡す
- `docs/PRODUCTION_SETUP.md`: Vercel Protection Bypass の設定手順を追記

## テスト結果

- `npm run typecheck`: 0 errors
- `npm run lint` (変更ファイル): 0 errors
- `npm run test:unit`: **267 tests passed** (19 files)
- サイズ: **25行 / 3ファイル** (制限: 300行 / 10ファイル)

## テスト計画

- [ ] Vercel Dashboard で Protection Bypass for Automation を有効化
- [ ] `VERCEL_AUTOMATION_BYPASS_SECRET` を GitHub Secrets に設定
- [ ] E2E テストが Preview デプロイで正常に実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)