### PR TITLE
fix: TypeScript strict オプション強化（noUncheckedIndexedAccess + noImplicitReturns）

### DIFF
--- a/app/_actions/__tests__/classification-rule-actions.test.ts
+++ b/app/_actions/__tests__/classification-rule-actions.test.ts
@@ -134,7 +134,7 @@ describe("getClassificationRules", () => {
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data).toHaveLength(1);
-			expect(result.data[0].instruction).toBe("AWSの利用料は通信費にしてください");
+			expect(result.data[0]!.instruction).toBe("AWSの利用料は通信費にしてください");
 		}
 	});
 

--- a/app/_actions/__tests__/import-actions.test.ts
+++ b/app/_actions/__tests__/import-actions.test.ts
@@ -213,7 +213,7 @@ describe("importTransactions", () => {
 
 		await importTransactions(validInput);
 
-		const insertedRows = txInsertChain.insert.mock.calls[0][0];
+		const insertedRows = txInsertChain.insert!.mock.calls[0]![0];
 		expect(insertedRows[0]).toEqual(
 			expect.objectContaining({
 				debit_account: "EXP010",
@@ -241,7 +241,7 @@ describe("importTransactions", () => {
 			],
 		});
 
-		const insertedRows = txInsertChain.insert.mock.calls[0][0];
+		const insertedRows = txInsertChain.insert!.mock.calls[0]![0];
 		expect(insertedRows[0].amount).toBe(1501);
 		expect(insertedRows[1].amount).toBe(2999);
 	});
@@ -264,7 +264,7 @@ describe("importTransactions", () => {
 			],
 		});
 
-		const insertedRows = txInsertChain.insert.mock.calls[0][0];
+		const insertedRows = txInsertChain.insert!.mock.calls[0]![0];
 		expect(insertedRows).toHaveLength(2);
 		expect(insertedRows.every((r: { amount: number }) => r.amount > 0)).toBe(true);
 		expect(logUpdateChain.update).toHaveBeenCalledWith(

--- a/components/__tests__/ai-classify-dialog.test.tsx
+++ b/components/__tests__/ai-classify-dialog.test.tsx
@@ -122,7 +122,7 @@ describe("AiClassifyDialog ルール保存エラーハンドリング", () => {
 			return btn.querySelector("svg.lucide-x") !== null;
 		});
 		expect(deleteButtons.length).toBeGreaterThan(0);
-		fireEvent.click(deleteButtons[0]);
+		fireEvent.click(deleteButtons[0]!);
 
 		await waitFor(() => {
 			expect(mockToast).toHaveBeenCalledWith(
@@ -152,7 +152,7 @@ describe("AiClassifyDialog ルール保存エラーハンドリング", () => {
 		const deleteButtons = screen.getAllByRole("button").filter((btn) => {
 			return btn.querySelector("svg.lucide-x") !== null;
 		});
-		fireEvent.click(deleteButtons[0]);
+		fireEvent.click(deleteButtons[0]!);
 
 		await waitFor(() => {
 			expect(mockToast).toHaveBeenCalledWith(

--- a/lib/claude/__tests__/client.test.ts
+++ b/lib/claude/__tests__/client.test.ts
@@ -64,10 +64,10 @@ describe("classifyTransactions", () => {
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data).toHaveLength(1);
-			expect(result.data[0].debitAccount).toBe("EXP001");
-			expect(result.data[0].creditAccount).toBe("AST002");
-			expect(result.data[0].confidence).toBe("HIGH");
-			expect(result.data[0].reason).toBeTruthy();
+			expect(result.data[0]!.debitAccount).toBe("EXP001");
+			expect(result.data[0]!.creditAccount).toBe("AST002");
+			expect(result.data[0]!.confidence).toBe("HIGH");
+			expect(result.data[0]!.reason).toBeTruthy();
 		}
 	});
 
@@ -108,8 +108,8 @@ describe("classifyTransactions", () => {
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data).toHaveLength(2);
-			expect(result.data[0].debitAccount).toBe("EXP001");
-			expect(result.data[1].debitAccount).toBe("EXP003");
+			expect(result.data[0]!.debitAccount).toBe("EXP001");
+			expect(result.data[1]!.debitAccount).toBe("EXP003");
 		}
 	});
 
@@ -210,7 +210,7 @@ describe("classifyTransactions", () => {
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data).toHaveLength(1);
-			expect(result.data[0].debitAccount).toBe("EXP001");
+			expect(result.data[0]!.debitAccount).toBe("EXP001");
 		}
 	});
 

--- a/lib/csv/parsers.ts
+++ b/lib/csv/parsers.ts
@@ -124,14 +124,14 @@ export function normalizeDate(dateStr: string): string {
 	// DD-MM-YYYY or DD/MM/YYYY
 	const dmyMatch = dateStr.match(/^(\d{1,2})[/-](\d{1,2})[/-](\d{4})/);
 	if (dmyMatch) {
-		const [, day, month, year] = dmyMatch;
+		const [, day = "", month = "", year = ""] = dmyMatch;
 		return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
 	}
 
 	// YYYY/MM/DD (Japanese card statements)
 	const ymdSlashMatch = dateStr.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})/);
 	if (ymdSlashMatch) {
-		const [, year, month, day] = ymdSlashMatch;
+		const [, year = "", month = "", day = ""] = ymdSlashMatch;
 		return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
 	}
 
@@ -143,7 +143,7 @@ export function normalizeDate(dateStr: string): string {
 
 	// ISO format: 2025-01-15T10:30:00Z
 	const isoMatch = dateStr.match(/^(\d{4}-\d{2}-\d{2})T/);
-	if (isoMatch) {
+	if (isoMatch?.[1]) {
 		return isoMatch[1];
 	}
 
@@ -185,7 +185,7 @@ function splitCsvLine(line: string): string[] {
 	let inQuotes = false;
 
 	for (let i = 0; i < line.length; i++) {
-		const char = line[i];
+		const char = line[i] ?? "";
 		if (char === '"') {
 			if (inQuotes && line[i + 1] === '"') {
 				current += '"';
@@ -211,14 +211,20 @@ export function parseRakutenCsv(csvText: string): ParsedTransaction[] {
 	const lines = csvText.split(/\r?\n/).filter((line) => line.trim() !== "");
 	if (lines.length < 2) return [];
 
-	const headers = splitCsvLine(lines[0]);
+	const headerLine = lines[0];
+	if (!headerLine) return [];
+	const headers = splitCsvLine(headerLine);
 	const transactions: ParsedTransaction[] = [];
 
 	for (let i = 1; i < lines.length; i++) {
-		const columns = splitCsvLine(lines[i]);
+		const line = lines[i];
+		if (!line) continue;
+		const columns = splitCsvLine(line);
 		const row: Record<string, string> = {};
 		for (let j = 0; j < headers.length; j++) {
-			row[headers[j]] = columns[j] ?? "";
+			const key = headers[j];
+			if (key === undefined) continue;
+			row[key] = columns[j] ?? "";
 		}
 
 		const parsed = rakutenRowSchema.safeParse(row);
@@ -242,15 +248,18 @@ export function parseRakutenCsv(csvText: string): ParsedTransaction[] {
  * - 2行目: カラム数 6以上、1列目が YYYY/MM/DD パターン
  */
 export function detectSmbcFromContent(lines: string[]): boolean {
-	if (lines.length < 2) return false;
+	const firstLine = lines[0];
+	const secondLine = lines[1];
+	if (!firstLine || !secondLine) return false;
 
-	const firstLineColumns = lines[0].split(",").length;
+	const firstLineColumns = firstLine.split(",").length;
 	if (firstLineColumns >= 5) return false;
 
-	const secondLineColumns = lines[1].split(",");
+	const secondLineColumns = secondLine.split(",");
 	if (secondLineColumns.length < 6) return false;
 
-	return /^\d{4}\/\d{1,2}\/\d{1,2}$/.test(secondLineColumns[0]);
+	const firstColumn = secondLineColumns[0];
+	return firstColumn !== undefined && /^\d{4}\/\d{1,2}\/\d{1,2}$/.test(firstColumn);
 }
 
 /**
@@ -275,14 +284,17 @@ export function parseSmbcCsv(csvText: string): ParsedTransaction[] {
 
 	// 1行目は契約者情報なのでスキップ（i=1 から開始）
 	for (let i = 1; i < lines.length; i++) {
-		const columns = lines[i].split(",");
+		const line = lines[i];
+		if (!line) continue;
+		const columns = line.split(",");
 		if (columns.length < 3) continue;
 
-		const row = {
-			date: columns[0],
-			description: columns[1],
-			amount: columns[2],
-		};
+		const date = columns[0];
+		const description = columns[1];
+		const amount = columns[2];
+		if (!date || !description || !amount) continue;
+
+		const row = { date, description, amount };
 
 		const parsed = smbcRowSchema.safeParse(row);
 		if (!parsed.success) continue;
@@ -308,14 +320,20 @@ export function parseWiseCsv(csvText: string): ParsedTransaction[] {
 	const lines = csvText.split(/\r?\n/).filter((line) => line.trim() !== "");
 	if (lines.length < 2) return [];
 
-	const headers = splitCsvLine(lines[0]);
+	const headerLine = lines[0];
+	if (!headerLine) return [];
+	const headers = splitCsvLine(headerLine);
 	const transactions: ParsedTransaction[] = [];
 
 	for (let i = 1; i < lines.length; i++) {
-		const columns = splitCsvLine(lines[i]);
+		const line = lines[i];
+		if (!line) continue;
+		const columns = splitCsvLine(line);
 		const row: Record<string, string> = {};
 		for (let j = 0; j < headers.length; j++) {
-			row[headers[j]] = columns[j] ?? "";
+			const key = headers[j];
+			if (key === undefined) continue;
+			row[key] = columns[j] ?? "";
 		}
 
 		const parsed = wiseRowSchema.safeParse(row);
@@ -349,15 +367,21 @@ export function parseRevolutCsv(csvText: string): ParsedTransaction[] {
 	const lines = csvText.split(/\r?\n/).filter((line) => line.trim() !== "");
 	if (lines.length < 2) return [];
 
-	const headers = splitCsvLine(lines[0]);
+	const headerLine = lines[0];
+	if (!headerLine) return [];
+	const headers = splitCsvLine(headerLine);
 	const isJapanese = headers.some((h) => h.trim() === "お取引");
 	const transactions: ParsedTransaction[] = [];
 
 	for (let i = 1; i < lines.length; i++) {
-		const columns = splitCsvLine(lines[i]);
+		const line = lines[i];
+		if (!line) continue;
+		const columns = splitCsvLine(line);
 		const row: Record<string, string> = {};
 		for (let j = 0; j < headers.length; j++) {
-			row[headers[j]] = columns[j] ?? "";
+			const key = headers[j];
+			if (key === undefined) continue;
+			row[key] = columns[j] ?? "";
 		}
 
 		if (isJapanese) {
@@ -408,14 +432,20 @@ export function parseGenericCsv(csvText: string): ParsedTransaction[] {
 	const lines = csvText.split(/\r?\n/).filter((line) => line.trim() !== "");
 	if (lines.length < 2) return [];
 
-	const headers = splitCsvLine(lines[0]);
+	const headerLine = lines[0];
+	if (!headerLine) return [];
+	const headers = splitCsvLine(headerLine);
 	const transactions: ParsedTransaction[] = [];
 
 	for (let i = 1; i < lines.length; i++) {
-		const columns = splitCsvLine(lines[i]);
+		const line = lines[i];
+		if (!line) continue;
+		const columns = splitCsvLine(line);
 		const row: Record<string, string> = {};
 		for (let j = 0; j < headers.length; j++) {
-			row[headers[j]] = columns[j] ?? "";
+			const key = headers[j];
+			if (key === undefined) continue;
+			row[key] = columns[j] ?? "";
 		}
 
 		const parsed = genericRowSchema.safeParse(row);
@@ -450,7 +480,9 @@ export function parseCsv(csvText: string): {
 		return { format: "smbc", transactions: parseSmbcCsv(csvText) };
 	}
 
-	const headers = splitCsvLine(lines[0]);
+	const firstLine = lines[0];
+	if (!firstLine) return { format: "generic", transactions: [] };
+	const headers = splitCsvLine(firstLine);
 	const format = detectCsvFormat(headers);
 
 	switch (format) {

--- a/tests/unit/lib/__tests__/csv-parsers.test.ts
+++ b/tests/unit/lib/__tests__/csv-parsers.test.ts
@@ -148,18 +148,18 @@ describe("CSV パーサー", () => {
 
 		it("日付をYYYY-MM-DD形式に正規化する", () => {
 			const result = parseRakutenCsv(rakutenCsv);
-			expect(result[0].date).toBe("2025-01-15");
+			expect(result[0]!.date).toBe("2025-01-15");
 		});
 
 		it("利用店名をdescriptionにマッピングする", () => {
 			const result = parseRakutenCsv(rakutenCsv);
-			expect(result[0].description).toBe("Amazon.co.jp");
+			expect(result[0]!.description).toBe("Amazon.co.jp");
 		});
 
 		it("利用金額を整数にパースする", () => {
 			const result = parseRakutenCsv(rakutenCsv);
-			expect(result[0].amount).toBe(3500);
-			expect(result[1].amount).toBe(850);
+			expect(result[0]!.amount).toBe(3500);
+			expect(result[1]!.amount).toBe(850);
 		});
 
 		it("空行を無視する", () => {
@@ -185,7 +185,7 @@ describe("CSV パーサー", () => {
 			].join("\r\n");
 			const result = parseRakutenCsv(crlfCsv);
 			expect(result).toHaveLength(1);
-			expect(result[0].amount).toBe(3500);
+			expect(result[0]!.amount).toBe(3500);
 		});
 
 		it('エスケープクォート（""）を単一の"に変換する', () => {
@@ -194,7 +194,7 @@ describe("CSV パーサー", () => {
 				'"2025/01/15","Amazon ""プライム""","本人","1回払い","500","0","500"',
 			].join("\n");
 			const result = parseRakutenCsv(csvWithEscaped);
-			expect(result[0].description).toBe('Amazon "プライム"');
+			expect(result[0]!.description).toBe('Amazon "プライム"');
 		});
 	});
 
@@ -238,18 +238,18 @@ describe("CSV パーサー", () => {
 
 		it("日付をYYYY-MM-DD形式に正規化する", () => {
 			const result = parseSmbcCsv(smbcCsv);
-			expect(result[0].date).toBe("2025-01-15");
+			expect(result[0]!.date).toBe("2025-01-15");
 		});
 
 		it("利用先をdescriptionにマッピングする", () => {
 			const result = parseSmbcCsv(smbcCsv);
-			expect(result[0].description).toBe("Amazon.co.jp");
+			expect(result[0]!.description).toBe("Amazon.co.jp");
 		});
 
 		it("利用金額を整数にパースする", () => {
 			const result = parseSmbcCsv(smbcCsv);
-			expect(result[0].amount).toBe(5000);
-			expect(result[1].amount).toBe(850);
+			expect(result[0]!.amount).toBe(5000);
+			expect(result[1]!.amount).toBe(850);
 		});
 
 		it("1行目（契約者情報）をスキップする", () => {
@@ -285,7 +285,7 @@ describe("CSV パーサー", () => {
 			const crlfCsv = ["太郎,1234", "2025/01/15,Amazon.co.jp,5000,1回,5000,,,"].join("\r\n");
 			const result = parseSmbcCsv(crlfCsv);
 			expect(result).toHaveLength(1);
-			expect(result[0].amount).toBe(5000);
+			expect(result[0]!.amount).toBe(5000);
 		});
 	});
 
@@ -299,13 +299,13 @@ describe("CSV パーサー", () => {
 		it("Wise CSVをパースして取引一覧を返す", () => {
 			const result = parseWiseCsv(wiseCsv);
 			expect(result).toHaveLength(2);
-			expect(result[0].date).toBe("2025-01-15");
-			expect(result[0].amount).toBe(-50);
-			expect(result[0].originalCurrency).toBe("GBP");
-			expect(result[0].exchangeRate).toBe(190.5);
-			expect(result[0].payeeName).toBe("John Doe");
-			expect(result[0].reference).toBe("REF001");
-			expect(result[0].fees).toBe(3);
+			expect(result[0]!.date).toBe("2025-01-15");
+			expect(result[0]!.amount).toBe(-50);
+			expect(result[0]!.originalCurrency).toBe("GBP");
+			expect(result[0]!.exchangeRate).toBe(190.5);
+			expect(result[0]!.payeeName).toBe("John Doe");
+			expect(result[0]!.reference).toBe("REF001");
+			expect(result[0]!.fees).toBe(3);
 		});
 
 		it("データ行が無い場合は空配列を返す", () => {
@@ -335,10 +335,10 @@ describe("CSV パーサー", () => {
 		it("Revolut CSVをパースして取引一覧を返す", () => {
 			const result = parseRevolutCsv(revolutCsv);
 			expect(result).toHaveLength(2);
-			expect(result[0].date).toBe("2025-01-15");
-			expect(result[0].description).toBe("Netflix");
-			expect(result[0].amount).toBe(-1500);
-			expect(result[0].originalCurrency).toBe("JPY");
+			expect(result[0]!.date).toBe("2025-01-15");
+			expect(result[0]!.description).toBe("Netflix");
+			expect(result[0]!.amount).toBe(-1500);
+			expect(result[0]!.originalCurrency).toBe("JPY");
 		});
 
 		it("データ行が無い場合は空配列を返す", () => {
@@ -364,7 +364,7 @@ describe("CSV パーサー", () => {
 			].join("\n");
 			const result = parseRevolutCsv(csvWithZeroAmount);
 			expect(result).toHaveLength(1);
-			expect(result[0].description).toBe("Netflix");
+			expect(result[0]!.description).toBe("Netflix");
 		});
 	});
 
@@ -378,15 +378,15 @@ describe("CSV パーサー", () => {
 		it("日本語版CSVをパースして取引一覧を返す", () => {
 			const result = parseRevolutCsv(revolutJaCsv);
 			expect(result).toHaveLength(2);
-			expect(result[0].description).toBe("Emart K.w Sepang");
-			expect(result[0].amount).toBe(-1751);
-			expect(result[0].originalCurrency).toBe("JPY");
+			expect(result[0]!.description).toBe("Emart K.w Sepang");
+			expect(result[0]!.amount).toBe(-1751);
+			expect(result[0]!.originalCurrency).toBe("JPY");
 		});
 
 		it("日付（YYYY-MM-DD HH:MM:SS）をYYYY-MM-DDに正規化する", () => {
 			const result = parseRevolutCsv(revolutJaCsv);
-			expect(result[0].date).toBe("2025-01-01");
-			expect(result[1].date).toBe("2025-01-03");
+			expect(result[0]!.date).toBe("2025-01-01");
+			expect(result[1]!.date).toBe("2025-01-03");
 		});
 
 		it("「差し戻された」ステータスの行をスキップする", () => {
@@ -397,7 +397,7 @@ describe("CSV パーサー", () => {
 			].join("\n");
 			const result = parseRevolutCsv(csvWithReverted);
 			expect(result).toHaveLength(1);
-			expect(result[0].description).toBe("Emart");
+			expect(result[0]!.description).toBe("Emart");
 		});
 
 		it("金額0の行をスキップする", () => {
@@ -408,7 +408,7 @@ describe("CSV パーサー", () => {
 			].join("\n");
 			const result = parseRevolutCsv(csvWithZeroAmount);
 			expect(result).toHaveLength(1);
-			expect(result[0].description).toBe("Netflix");
+			expect(result[0]!.description).toBe("Netflix");
 		});
 
 		it("手数料が0以外の場合feesにマッピングする", () => {
@@ -418,8 +418,8 @@ describe("CSV パーサー", () => {
 				"カード支払い,当座,2025-01-01 06:00:00,2025-01-02 22:11:53,Netflix,-1500,0,JPY,完了済み,98500",
 			].join("\n");
 			const result = parseRevolutCsv(csvWithFees);
-			expect(result[0].fees).toBe(150);
-			expect(result[1].fees).toBeUndefined();
+			expect(result[0]!.fees).toBe(150);
+			expect(result[1]!.fees).toBeUndefined();
 		});
 	});
 
@@ -433,9 +433,9 @@ describe("CSV パーサー", () => {
 		it("汎用CSVをパースして取引一覧を返す", () => {
 			const result = parseGenericCsv(genericCsv);
 			expect(result).toHaveLength(2);
-			expect(result[0].date).toBe("2025-01-15");
-			expect(result[0].description).toBe("通信費");
-			expect(result[0].amount).toBe(5000);
+			expect(result[0]!.date).toBe("2025-01-15");
+			expect(result[0]!.description).toBe("通信費");
+			expect(result[0]!.amount).toBe(5000);
 		});
 
 		it("データ行が無い場合は空配列を返す", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
 		"allowJs": true,
 		"skipLibCheck": true,
 		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"noImplicitReturns": true,
 		"noEmit": true,
 		"esModuleInterop": true,
 		"module": "esnext",


### PR DESCRIPTION
## 概要
Closes #80

`tsconfig.json` に `noUncheckedIndexedAccess` と `noImplicitReturns` を追加し、配列・オブジェクトのインデックスアクセス時に `undefined` の可能性を型レベルで強制チェックする。発生した73件のコンパイルエラーを全て修正。

## 変更内容

### 設定変更
- **tsconfig.json**: `noUncheckedIndexedAccess: true` + `noImplicitReturns: true` を追加

### プロダクションコード（`lib/csv/parsers.ts`）— 22箇所
- 配列アクセス前にガードチェック追加（`if (!line) continue` 等）
- regex destructuring にデフォルト値追加（`const [, day = "", month = ""] = match`）
- オブジェクトキーアクセスに `undefined` チェック追加

### テストコード — 51箇所（5ファイル）
- テスト内の配列インデックスアクセスに `!` non-null assertion 追加
  - `tests/unit/lib/__tests__/csv-parsers.test.ts` (35件)
  - `lib/claude/__tests__/client.test.ts` (7件)
  - `app/_actions/__tests__/import-actions.test.ts` (6件)
  - `components/__tests__/ai-classify-dialog.test.tsx` (2件)
  - `app/_actions/__tests__/classification-rule-actions.test.ts` (1件)

## テスト結果
- `npm run typecheck`: ✅ Pass（エラー 0件）
- `npm run lint`: ✅ Pass（既存の警告のみ）
- `npm run test:unit`: ✅ 20 files, 273 tests all passed
- `npm run build`: ✅ Success

## PRサイズ
- 7 files changed, 109 insertions(+), 75 deletions(-)
- ≤ 300行 / ≤ 10ファイル ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)