### PR TITLE
fix: gitleaks 誤検知修正 — テストのダミーAPIキー値を変更

### DIFF
--- a/lib/__tests__/env.test.ts
+++ b/lib/__tests__/env.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 describe("env", () => {
 	const VALID_ENV = {
 		NEXT_PUBLIC_SUPABASE_URL: "https://example.supabase.co",
-		NEXT_PUBLIC_SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test-key",
+		NEXT_PUBLIC_SUPABASE_ANON_KEY: "test-anon-key-dummy-value",
 	};
 
 	let originalEnv: NodeJS.ProcessEnv;


### PR DESCRIPTION
## 概要
CI の Security Scan (gitleaks) が `lib/__tests__/env.test.ts` のダミーAPIキー値を `generic-api-key` として誤検知していたため、JWT風フォーマットに似ないシンプルな文字列に変更。

## 変更内容
- `lib/__tests__/env.test.ts`: ダミー値 `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test-key` → `test-anon-key-dummy-value`

## 関連Issue
なし（CI修正）

## チェックリスト
- [x] `npm run typecheck` が通る
- [x] `npm run test:unit` が通る
- [x] 追加行数が 300 行以下 / 10 ファイル以下（1ファイル / +1 -1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)