### PR TITLE
chore: Dependabot 導入 — npm + GitHub Actions weekly 更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## 概要
Dependabot を導入し、npm パッケージと GitHub Actions の依存関係を weekly スケジュールで自動更新 PR を作成する。メジャーバージョン更新は手動レビュー前提。

## 変更内容
- `.github/dependabot.yml` (新規): Dependabot 設定ファイル
  - `npm`: weekly 更新、PR 上限 10件
  - `github-actions`: weekly 更新、PR 上限 5件
  - 自動マージ設定なし（全 PR 手動レビュー）

## 関連Issue
Closes #83

## TDD 実施確認
設定ファイルのみのため TDD 対象外

## テスト結果
コード変更なし、テスト影響なし

## セルフレビューチェック
- [x] 差分を全て自分で読み直した
- [x] `any` 型を使用していない（該当なし）
- [x] `console.log` が残っていない（該当なし）
- [x] ハードコードされた文字列がない

## チェックリスト
- [x] 追加行数が 300 行以下 / 10 ファイル以下（1ファイル / +13行）
- [x] 環境変数の追加はないか（なし）
- [x] 破壊的変更がある場合、マイグレーション手順を記載した（破壊的変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)