### PR TITLE
fix: Dependabot PR での Build 失敗を修正（環境変数フォールバック追加）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ concurrency:
 
 env:
   NODE_VERSION: "22"
-  NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-  NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+  NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
 
 jobs:
   # ============================================


### PR DESCRIPTION
## Summary
- CI の Build ジョブが全 Dependabot PR で失敗していた問題を修正
- `ci.yml` の `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` にフォールバック値を追加
- Dependabot PR では GitHub Secrets にアクセスできないため、`lib/env.ts` の Zod バリデーションで空文字が拒否され Build 失敗していた

## 変更内容
- `.github/workflows/ci.yml`: env セクションに `|| 'placeholder'` フォールバックを追加
- `e2e.yml` は Vercel Preview URL を使用しており `NEXT_PUBLIC_SUPABASE_*` 不要 → 変更なし
- Lighthouse ジョブは `ci.yml` 内で `env` を継承 → 追加対応なし

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run test:unit` — 295テスト全通過
- [x] CI ワークフローの YAML 構文確認済み
- [ ] マージ後に Dependabot PR の CI を再実行して Build 通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)