### PR TITLE
chore: actions/setup-node を v4 から v6 に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -43,7 +43,7 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -61,7 +61,7 @@ jobs:
     needs: typecheck
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -86,7 +86,7 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -141,7 +141,7 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"


### PR DESCRIPTION
## 概要
Dependabot PR #93 がci.yml変更と競合していたため、手動で `actions/setup-node` を v4 から v6 に更新。

## 変更内容
- `ci.yml`: 全6ジョブの `actions/setup-node@v4` → `actions/setup-node@v6`
- `e2e.yml`: `actions/setup-node@v4` → `actions/setup-node@v6`

## 関連Issue
Closes #93 の代替対応

## テスト結果
```
Test Files  25 passed (25)
Tests       295 passed (295)
```

- テストケース数: 295件
- カバレッジ: 変更なし（CI設定のみ）

## セルフレビューチェック
- [x] 差分を全て自分で読み直した
- [x] `any` 型を使用していない
- [x] `console.log` が残っていない
- [x] エラーは `handleApiError()` で処理している
- [x] 新しい環境変数に `NEXT_PUBLIC_` を不要に付けていない
- [x] ハードコードされた文字列がない
- [x] RLS ポリシーの確認（DB 変更なし）

## チェックリスト
- [x] `npm run typecheck` が通る
- [x] `npm run lint` が通る（既存の警告のみ、新規エラーなし）
- [x] `npm run test:unit` が通る
- [x] 追加行数が 300 行以下 / 10 ファイル以下（2ファイル, 14行）
- [x] 環境変数の追加はない
- [x] 破壊的変更なし