### PR TITLE
fix: E2E transactions テストの日付を動的に変更（ページネーション問題解消）

### DIFF
--- a/tests/e2e/transactions.spec.ts
+++ b/tests/e2e/transactions.spec.ts
@@ -2,6 +2,8 @@ import { expect, test } from "@playwright/test";
 
 test.describe("Transactions", () => {
 	const testDescription = `E2Eテスト取引 ${Date.now()}`;
+	// Use today's date so the transaction appears on page 1 (default sort: transaction_date DESC)
+	const today = new Date().toISOString().split("T")[0];
 
 	test("should create a new transaction", async ({ page }) => {
 		await page.goto("/transactions/new");
@@ -13,7 +15,7 @@ test.describe("Transactions", () => {
 			setter?.call(input, val);
 			input.dispatchEvent(new Event("input", { bubbles: true }));
 			input.dispatchEvent(new Event("change", { bubbles: true }));
-		}, "2025-01-15");
+		}, today);
 
 		await page.locator("#description").fill(testDescription);
 		await page.locator("#amount").fill("1000");


### PR DESCRIPTION
## 概要

E2E テスト `transactions.spec.ts` の「should create a new transaction」が CI で失敗していた問題を修正。

## 変更内容

- 取引作成テストの日付を `2025-01-15`（ハードコード）から `new Date().toISOString().split("T")[0]`（当日の日付）に変更

## 原因

取引一覧のデフォルトソートは `transaction_date DESC`（新しい順）、1ページ20件。テストデータが蓄積され、2025-01-15 の取引が2ページ目以降に押し出されたため、1ページ目で `toBeVisible` が失敗していた。

## テスト結果

- **Unit tests**: 295 passed (25 files)
- **TypeCheck**: OK
- **Lint**: 既存の警告のみ（今回の変更に関連なし）

## チェックリスト

- [x] テストが通ること
- [x] 型チェックが通ること
- [x] 300行以下 / 10ファイル以下

🤖 Generated with [Claude Code](https://claude.com/claude-code)