### PR TITLE
fix: Claude API を tool_use（structured output）に移行

### DIFF
--- a/lib/claude/__tests__/client.test.ts
+++ b/lib/claude/__tests__/client.test.ts
@@ -17,9 +17,18 @@ import type { TransactionInput } from "@/lib/claude/types";
 const UUID_1 = "550e8400-e29b-41d4-a716-446655440000";
 const UUID_2 = "550e8400-e29b-41d4-a716-446655440001";
 
-/** プリフィル「{」を考慮し、先頭の { を除いた文字列を返す */
-function withoutLeadingBrace(obj: unknown): string {
-	return JSON.stringify(obj).slice(1);
+function toolUseResponse(input: unknown) {
+	return {
+		content: [
+			{
+				type: "tool_use",
+				id: "toolu_test_123",
+				name: "classify_transactions",
+				input,
+			},
+		],
+		stop_reason: "tool_use",
+	};
 }
 
 const sampleInput: TransactionInput[] = [
@@ -31,24 +40,16 @@ const sampleInput: TransactionInput[] = [
 	},
 ];
 
-const validApiResponse = {
-	content: [
+const validClassifications = {
+	classifications: [
 		{
-			type: "text",
-			text: withoutLeadingBrace({
-				classifications: [
-					{
-						id: UUID_1,
-						debitAccount: "EXP001",
-						creditAccount: "AST002",
-						confidence: "HIGH",
-						reason: "クラウドサービス利用料は通信費に該当",
-					},
-				],
-			}),
+			id: UUID_1,
+			debitAccount: "EXP001",
+			creditAccount: "AST002",
+			confidence: "HIGH",
+			reason: "クラウドサービス利用料は通信費に該当",
 		},
 	],
-	stop_reason: "end_turn",
 };
 
 describe("classifyTransactions", () => {
@@ -57,7 +58,7 @@ describe("classifyTransactions", () => {
 	});
 
 	it("単一取引の仕訳を推定できる", async () => {
-		mockCreate.mockResolvedValue(validApiResponse);
+		mockCreate.mockResolvedValue(toolUseResponse(validClassifications));
 
 		const result = await classifyTransactions(sampleInput);
 
@@ -76,32 +77,26 @@ describe("classifyTransactions", () => {
 			{ id: UUID_1, date: "2026-01-15", description: "AWS利用料", amount: 5000 },
 			{ id: UUID_2, date: "2026-01-16", description: "電車代", amount: 500 },
 		];
-		mockCreate.mockResolvedValue({
-			content: [
-				{
-					type: "text",
-					text: withoutLeadingBrace({
-						classifications: [
-							{
-								id: UUID_1,
-								debitAccount: "EXP001",
-								creditAccount: "AST002",
-								confidence: "HIGH",
-								reason: "クラウドサービス",
-							},
-							{
-								id: UUID_2,
-								debitAccount: "EXP003",
-								creditAccount: "AST001",
-								confidence: "HIGH",
-								reason: "交通費",
-							},
-						],
-					}),
-				},
-			],
-			stop_reason: "end_turn",
-		});
+		mockCreate.mockResolvedValue(
+			toolUseResponse({
+				classifications: [
+					{
+						id: UUID_1,
+						debitAccount: "EXP001",
+						creditAccount: "AST002",
+						confidence: "HIGH",
+						reason: "クラウドサービス",
+					},
+					{
+						id: UUID_2,
+						debitAccount: "EXP003",
+						creditAccount: "AST001",
+						confidence: "HIGH",
+						reason: "交通費",
+					},
+				],
+			}),
+		);
 
 		const result = await classifyTransactions(multiInput);
 
@@ -113,8 +108,24 @@ describe("classifyTransactions", () => {
 		}
 	});
 
+	it("messages.create に tools パラメータが含まれる", async () => {
+		mockCreate.mockResolvedValue(toolUseResponse(validClassifications));
+
+		await classifyTransactions(sampleInput);
+
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tools: expect.arrayContaining([
+					expect.objectContaining({
+						name: "classify_transactions",
+					}),
+				]),
+			}),
+		);
+	});
+
 	it("messages.create にシステムプロンプトが含まれる", async () => {
-		mockCreate.mockResolvedValue(validApiResponse);
+		mockCreate.mockResolvedValue(toolUseResponse(validClassifications));
 
 		await classifyTransactions(sampleInput);
 
@@ -123,6 +134,18 @@ describe("classifyTransactions", () => {
 				system: expect.stringContaining("勘定科目"),
 			}),
 		);
+	});
+
+	it("messages.create に assistant プリフィルが含まれない", async () => {
+		mockCreate.mockResolvedValue(toolUseResponse(validClassifications));
+
+		await classifyTransactions(sampleInput);
+
+		const callArgs = mockCreate.mock.calls[0]![0];
+		const assistantMessage = callArgs.messages.find(
+			(m: { role: string }) => m.role === "assistant",
+		);
+		expect(assistantMessage).toBeUndefined();
 	});
 
 	it("APIエラー時にAI_ERRORを返す", async () => {
@@ -150,11 +173,22 @@ describe("classifyTransactions", () => {
 		}
 	});
 
-	it("不正なAPIレスポンスでエラーを返す", async () => {
+	it("tool_useブロックがないレスポンスでエラーを返す", async () => {
 		mockCreate.mockResolvedValue({
-			content: [{ type: "text", text: "これはJSONではありません" }],
+			content: [{ type: "text", text: "テキストのみのレスポンス" }],
 			stop_reason: "end_turn",
 		});
+
+		const result = await classifyTransactions(sampleInput);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("AI_ERROR");
+		}
+	});
+
+	it("不正なtool_use inputでエラーを返す", async () => {
+		mockCreate.mockResolvedValue(toolUseResponse({ invalid: "data" }));
 
 		const result = await classifyTransactions(sampleInput);
 
@@ -188,34 +222,8 @@ describe("classifyTransactions", () => {
 		}
 	});
 
-	it("マークダウンコードブロック付きJSONをパースできる", async () => {
-		const jsonContent = withoutLeadingBrace({
-			classifications: [
-				{
-					id: UUID_1,
-					debitAccount: "EXP001",
-					creditAccount: "AST002",
-					confidence: "HIGH",
-					reason: "通信費",
-				},
-			],
-		});
-		mockCreate.mockResolvedValue({
-			content: [{ type: "text", text: `\`\`\`json\n${jsonContent}\n\`\`\`` }],
-			stop_reason: "end_turn",
-		});
-
-		const result = await classifyTransactions(sampleInput);
-
-		expect(result.success).toBe(true);
-		if (result.success) {
-			expect(result.data).toHaveLength(1);
-			expect(result.data[0]!.debitAccount).toBe("EXP001");
-		}
-	});
-
 	it("ユーザー指示がプロンプトに含まれる", async () => {
-		mockCreate.mockResolvedValue(validApiResponse);
+		mockCreate.mockResolvedValue(toolUseResponse(validClassifications));
 
 		await classifyTransactions(sampleInput, "AWSは通信費にしてください");
 
@@ -232,7 +240,7 @@ describe("classifyTransactions", () => {
 	});
 
 	it("ユーザー指示なしで従来通り動作する", async () => {
-		mockCreate.mockResolvedValue(validApiResponse);
+		mockCreate.mockResolvedValue(toolUseResponse(validClassifications));
 
 		await classifyTransactions(sampleInput);
 

--- a/lib/claude/client.ts
+++ b/lib/claude/client.ts
@@ -2,7 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { ApiError, handleApiError } from "@/lib/api/error";
 import type { ApiResponse } from "@/lib/types/api";
 import { aiClassifyRequestSchema } from "@/lib/validators/transaction";
-import { buildUserPrompt, SYSTEM_PROMPT } from "./prompts";
+import { buildUserPrompt, CLASSIFY_TOOL, SYSTEM_PROMPT } from "./prompts";
 import {
 	type ClassifiedTransaction,
 	classificationResultSchema,
@@ -24,28 +24,21 @@ export async function classifyTransactions(
 			model: "claude-sonnet-4-5-20250929",
 			max_tokens: 4096,
 			system: SYSTEM_PROMPT,
+			tools: [CLASSIFY_TOOL],
+			tool_choice: { type: "tool", name: "classify_transactions" },
 			messages: [
 				{ role: "user", content: buildUserPrompt(parsed.data.transactions, userInstruction) },
-				{ role: "assistant", content: "{" },
 			],
 		});
 
-		const textBlock = response.content.find(
-			(block): block is Anthropic.TextBlock => block.type === "text",
+		const toolUseBlock = response.content.find(
+			(block): block is Anthropic.ToolUseBlock => block.type === "tool_use",
 		);
-		if (!textBlock) {
+		if (!toolUseBlock) {
 			throw new ApiError("AI_ERROR", "AIからの応答を取得できませんでした。");
 		}
 
-		const stripped = textBlock.text.replace(/^```(?:json)?\s*\n?|\n?```\s*$/g, "").trim();
-		const rawText = `{${stripped}`;
-		let json: unknown;
-		try {
-			json = JSON.parse(rawText);
-		} catch {
-			throw new ApiError("AI_ERROR", "AIの応答形式が不正です。");
-		}
-		const result = classificationResultSchema.safeParse(json);
+		const result = classificationResultSchema.safeParse(toolUseBlock.input);
 		if (!result.success) {
 			throw new ApiError("AI_ERROR", "AIの応答形式が不正です。");
 		}

--- a/lib/claude/prompts.ts
+++ b/lib/claude/prompts.ts
@@ -1,9 +1,12 @@
+import type Anthropic from "@anthropic-ai/sdk";
 import { ACCOUNT_CATEGORIES } from "@/lib/utils/constants";
 import type { TransactionInput } from "./types";
 
 const accountList = Object.entries(ACCOUNT_CATEGORIES)
 	.map(([code, info]) => `${code}: ${info.name}（${info.type}）`)
 	.join("\n");
+
+const accountCodes = Object.keys(ACCOUNT_CATEGORIES);
 
 export const SYSTEM_PROMPT = `あなたは日本のフリーランスIT技術者向けの確定申告アシスタントです。
 取引の摘要から適切な勘定科目を推定してください。
@@ -19,9 +22,36 @@ ${accountList}
 - 費用の支払いは通常: 借方=費用科目、貸方=資産科目（普通預金など）
 - 収入の受取は通常: 借方=資産科目、貸方=収入科目
 
-## 出力形式
-以下のJSON形式のみを返してください。説明文やマークダウンは不要です。
-{"classifications":[{"id":"取引ID","debitAccount":"借方コード","creditAccount":"貸方コード","confidence":"HIGH","reason":"理由"}]}`;
+classify_transactions ツールを使って結果を返してください。`;
+
+export const CLASSIFY_TOOL: Anthropic.Tool = {
+	name: "classify_transactions",
+	description: "取引の仕訳分類結果を返す",
+	input_schema: {
+		type: "object",
+		properties: {
+			classifications: {
+				type: "array",
+				items: {
+					type: "object",
+					properties: {
+						id: { type: "string", description: "取引ID" },
+						debitAccount: { type: "string", enum: accountCodes, description: "借方勘定科目コード" },
+						creditAccount: {
+							type: "string",
+							enum: accountCodes,
+							description: "貸方勘定科目コード",
+						},
+						confidence: { type: "string", enum: ["HIGH", "MEDIUM", "LOW"], description: "確信度" },
+						reason: { type: "string", description: "推定理由" },
+					},
+					required: ["debitAccount", "creditAccount", "confidence", "reason"],
+				},
+			},
+		},
+		required: ["classifications"],
+	},
+};
 
 export function buildUserPrompt(
 	transactions: TransactionInput[],


### PR DESCRIPTION
## 概要
`classifyTransactions` の JSON プリフィルハック（assistant role に `"{"` をセット）を廃止し、Anthropic SDK の tool_use を使った構造化レスポンス取得に移行。

## 変更内容
- **`lib/claude/prompts.ts`**: `CLASSIFY_TOOL` 定義を追加（`input_schema` に借方/貸方科目・確信度・理由を定義）。SYSTEM_PROMPT から JSON 出力形式の指示を削除し、tool 使用を指示する形式に変更
- **`lib/claude/client.ts`**: `messages.create` に `tools` + `tool_choice` パラメータを追加。assistant プリフィル `"{"` を削除。`ToolUseBlock` から `input` を抽出して Zod で検証する方式に変更
- **`lib/claude/__tests__/client.test.ts`**: モックを tool_use レスポンス形式に全面更新。`withoutLeadingBrace` ヘルパーを削除。`tools` パラメータ確認テスト・プリフィル不存在テスト・不正 tool_use input テストを追加

## テスト結果
- Unit Test: 316テスト全通過（29ファイル）
- TypeScript: 型エラー 0件
- Build: 成功

## テスト観点
- [x] tool_use レスポンスから正しく分類結果が抽出される（単一・複数取引）
- [x] `tools` パラメータが API 呼び出しに含まれる
- [x] assistant プリフィル `"{"` が除去されている
- [x] tool_use ブロックがないレスポンスでエラーハンドリング
- [x] 不正な tool_use input でエラーハンドリング
- [x] レート制限・API エラー・エラー詳細漏洩防止

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)