### PR TITLE
fix: updateTransaction の Record<string, unknown> を TablesUpdate 型に修正

### DIFF
--- a/app/_actions/transaction-commands.ts
+++ b/app/_actions/transaction-commands.ts
@@ -5,7 +5,7 @@ import { handleApiError } from "@/lib/api/error";
 import { requireAuth } from "@/lib/auth";
 import { createClient } from "@/lib/supabase/server";
 import type { ApiResponse } from "@/lib/types/api";
-import type { Tables } from "@/lib/types/supabase";
+import type { Tables, TablesUpdate } from "@/lib/types/supabase";
 import type { CreateTransactionInput, UpdateTransactionInput } from "@/lib/validators/transaction";
 import {
 	bulkConfirmSchema,
@@ -68,15 +68,17 @@ export async function updateTransaction(
 		}
 
 		const { id, isConfirmed, ...fields } = parsed.data;
-		const updateData: Record<string, unknown> = {};
-		if (fields.transactionDate !== undefined) updateData.transaction_date = fields.transactionDate;
-		if (fields.description !== undefined) updateData.description = fields.description;
-		if (fields.amount !== undefined) updateData.amount = fields.amount;
-		if (fields.debitAccount !== undefined) updateData.debit_account = fields.debitAccount;
-		if (fields.creditAccount !== undefined) updateData.credit_account = fields.creditAccount;
-		if (fields.taxCategory !== undefined) updateData.tax_category = fields.taxCategory;
-		if (fields.memo !== undefined) updateData.memo = fields.memo;
-		if (isConfirmed !== undefined) updateData.is_confirmed = isConfirmed;
+
+		const updateData: TablesUpdate<"transactions"> = {
+			...(fields.transactionDate !== undefined && { transaction_date: fields.transactionDate }),
+			...(fields.description !== undefined && { description: fields.description }),
+			...(fields.amount !== undefined && { amount: fields.amount }),
+			...(fields.debitAccount !== undefined && { debit_account: fields.debitAccount }),
+			...(fields.creditAccount !== undefined && { credit_account: fields.creditAccount }),
+			...(fields.taxCategory !== undefined && { tax_category: fields.taxCategory }),
+			...(fields.memo !== undefined && { memo: fields.memo }),
+			...(isConfirmed !== undefined && { is_confirmed: isConfirmed }),
+		};
 
 		const supabase = await createClient();
 		const { data, error } = await supabase


### PR DESCRIPTION
## 概要
`updateTransaction` の `Record<string, unknown>` を Supabase の `TablesUpdate<"transactions">` 型に置き換え、型安全性を向上させる。

## 変更内容
- `app/_actions/transaction-commands.ts`:
  - `Record<string, unknown>` → `TablesUpdate<"transactions">` に変更
  - if-undefined チェーン → conditional spread パターン（`...(value !== undefined && { key: value })`）に置き換え
  - `TablesUpdate` 型を import に追加

## テスト結果
- Unit Test: 316テスト全通過（29ファイル）
- TypeScript: 型エラー 0件
- Build: 成功
- 既存テスト27件が変更なしで全て通過（振る舞い変更なし）

## テスト観点
- [x] 部分更新（1フィールド / 複数フィールド）が正しく動作する
- [x] 無効なIDでバリデーションエラー
- [x] DBエラー時のエラー漏洩防止
- [x] `Record<string, unknown>` が完全に除去されている

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)