### PR TITLE
fix: tool_useのidフィールドをrequiredに変更しAI仕訳推定を修正

### DIFF
--- a/app/_actions/ai-classify-actions.ts
+++ b/app/_actions/ai-classify-actions.ts
@@ -4,7 +4,6 @@ import { revalidatePath } from "next/cache";
 import { handleApiError } from "@/lib/api/error";
 import { requireAuth } from "@/lib/auth";
 import { classifyTransactions } from "@/lib/claude/client";
-import type { ClassifiedTransaction } from "@/lib/claude/types";
 import { createClient } from "@/lib/supabase/server";
 import type { ApiResponse } from "@/lib/types/api";
 import { applyClassificationsSchema, bulkConfirmSchema } from "@/lib/validators/transaction";
@@ -74,20 +73,18 @@ export async function runAiClassification(
 			};
 		}
 
-		const rows: AiClassificationRow[] = classifyResult.data
-			.filter((c): c is ClassifiedTransaction & { id: string } => !!c.id)
-			.map((c) => {
-				const tx = transactions.find((t) => t.id === c.id);
-				return {
-					id: c.id,
-					description: tx?.description ?? "",
-					amount: tx?.amount ?? 0,
-					debitAccount: c.debitAccount,
-					creditAccount: c.creditAccount,
-					confidence: c.confidence,
-					reason: c.reason,
-				};
-			});
+		const rows: AiClassificationRow[] = classifyResult.data.map((c) => {
+			const tx = transactions.find((t) => t.id === c.id);
+			return {
+				id: c.id,
+				description: tx?.description ?? "",
+				amount: tx?.amount ?? 0,
+				debitAccount: c.debitAccount,
+				creditAccount: c.creditAccount,
+				confidence: c.confidence,
+				reason: c.reason,
+			};
+		});
 
 		return { success: true, data: rows };
 	} catch (error) {

--- a/lib/claude/__tests__/client.test.ts
+++ b/lib/claude/__tests__/client.test.ts
@@ -198,6 +198,28 @@ describe("classifyTransactions", () => {
 		}
 	});
 
+	it("idが欠落したclassificationsでエラーを返す", async () => {
+		mockCreate.mockResolvedValue(
+			toolUseResponse({
+				classifications: [
+					{
+						debitAccount: "EXP001",
+						creditAccount: "AST002",
+						confidence: "HIGH",
+						reason: "通信費",
+					},
+				],
+			}),
+		);
+
+		const result = await classifyTransactions(sampleInput);
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.code).toBe("AI_ERROR");
+		}
+	});
+
 	it("空の取引配列でバリデーションエラーを返す", async () => {
 		const result = await classifyTransactions([]);
 

--- a/lib/claude/prompts.ts
+++ b/lib/claude/prompts.ts
@@ -45,7 +45,7 @@ export const CLASSIFY_TOOL: Anthropic.Tool = {
 						confidence: { type: "string", enum: ["HIGH", "MEDIUM", "LOW"], description: "確信度" },
 						reason: { type: "string", description: "推定理由" },
 					},
-					required: ["debitAccount", "creditAccount", "confidence", "reason"],
+					required: ["id", "debitAccount", "creditAccount", "confidence", "reason"],
 				},
 			},
 		},

--- a/lib/claude/types.ts
+++ b/lib/claude/types.ts
@@ -6,7 +6,7 @@ const accountCodes = Object.keys(ACCOUNT_CATEGORIES) as [string, ...string[]];
 export const classificationResultSchema = z.object({
 	classifications: z.array(
 		z.object({
-			id: z.string().optional(),
+			id: z.string(),
 			debitAccount: z.enum(accountCodes),
 			creditAccount: z.enum(accountCodes),
 			confidence: z.enum(["HIGH", "MEDIUM", "LOW"]),
@@ -25,7 +25,7 @@ export interface TransactionInput {
 }
 
 export interface ClassifiedTransaction {
-	id?: string;
+	id: string;
 	debitAccount: string;
 	creditAccount: string;
 	confidence: "HIGH" | "MEDIUM" | "LOW";


### PR DESCRIPTION
## 概要
tool_use移行後、CLASSIFY_TOOLスキーマで`id`フィールドが`required`に含まれていなかったため、AIがidを省略する可能性があり、`runAiClassification`のフィルタ処理で全結果が除外される問題を修正。

## 変更内容
- `CLASSIFY_TOOL`の`input_schema`で`id`を`required`に追加（AIが必ずidを返すよう強制）
- `classificationResultSchema`（Zod）で`id`を`z.string()`に変更（optional→required）
- `ClassifiedTransaction`インターフェースの`id`を必須に変更
- `runAiClassification`から不要になった`filter((c) => !!c.id)`を削除
- 未使用の`ClassifiedTransaction`インポートを削除
- `id`欠落時にバリデーションエラーを返すテストを追加

## 関連Issue
N/A（tool_use移行 PR #122 のフォローアップ修正）

## TDD 実施確認
- [x] 🔴 テストを先に書いた（実装前にテスト失敗を確認）
- [x] 🟢 テストを通す最小限の実装を書いた
- [x] 🔵 テストが通る状態を維持してリファクタした
- [x] カバレッジが基準値を満たしている

## テスト結果
```
 Test Files  29 passed (29)
      Tests  317 passed (317)
   Duration  6.87s
```

- テストケース数: 317件（+1件追加）
- カバレッジ: 基準値達成

## セルフレビューチェック
- [x] 差分を全て自分で読み直した
- [x] `any` 型を使用していない
- [x] `console.log` が残っていない
- [x] エラーは `handleApiError()` で処理している
- [x] 新しい環境変数に `NEXT_PUBLIC_` を不要に付けていない
- [x] ハードコードされた文字列がない
- [x] RLS ポリシーの確認（DB 変更なし）

## チェックリスト
- [x] `npm run typecheck` が通る
- [x] `npm run lint` が通る
- [x] `npm run test:unit` が通る
- [x] 追加行数が 300 行以下 / 10 ファイル以下（4ファイル、55行）
- [x] 環境変数の追加はない
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)