### PR TITLE
chore: Biome 2.4.7 にアップデート + biome.json schema 更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
 				"zod": "4.3.6"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.4.4",
+				"@biomejs/biome": "2.4.7",
 				"@playwright/test": "1.58.2",
 				"@tailwindcss/postcss": "4.2.1",
 				"@testing-library/jest-dom": "6.9.1",
@@ -485,9 +485,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.4.tgz",
-			"integrity": "sha512-tigwWS5KfJf0cABVd52NVaXyAVv4qpUXOWJ1rxFL8xF1RVoeS2q/LK+FHgYoKMclJCuRoCWAPy1IXaN9/mS61Q==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.7.tgz",
+			"integrity": "sha512-vXrgcmNGZ4lpdwZSpMf1hWw1aWS6B+SyeSYKTLrNsiUsAdSRN0J4d/7mF3ogJFbIwFFSOL3wT92Zzxia/d5/ng==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -501,20 +501,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.4.4",
-				"@biomejs/cli-darwin-x64": "2.4.4",
-				"@biomejs/cli-linux-arm64": "2.4.4",
-				"@biomejs/cli-linux-arm64-musl": "2.4.4",
-				"@biomejs/cli-linux-x64": "2.4.4",
-				"@biomejs/cli-linux-x64-musl": "2.4.4",
-				"@biomejs/cli-win32-arm64": "2.4.4",
-				"@biomejs/cli-win32-x64": "2.4.4"
+				"@biomejs/cli-darwin-arm64": "2.4.7",
+				"@biomejs/cli-darwin-x64": "2.4.7",
+				"@biomejs/cli-linux-arm64": "2.4.7",
+				"@biomejs/cli-linux-arm64-musl": "2.4.7",
+				"@biomejs/cli-linux-x64": "2.4.7",
+				"@biomejs/cli-linux-x64-musl": "2.4.7",
+				"@biomejs/cli-win32-arm64": "2.4.7",
+				"@biomejs/cli-win32-x64": "2.4.7"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.4.tgz",
-			"integrity": "sha512-jZ+Xc6qvD6tTH5jM6eKX44dcbyNqJHssfl2nnwT6vma6B1sj7ZLTGIk6N5QwVBs5xGN52r3trk5fgd3sQ9We9A==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.7.tgz",
+			"integrity": "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA==",
 			"cpu": [
 				"arm64"
 			],
@@ -529,9 +529,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.4.tgz",
-			"integrity": "sha512-Dh1a/+W+SUCXhEdL7TiX3ArPTFCQKJTI1mGncZNWfO+6suk+gYA4lNyJcBB+pwvF49uw0pEbUS49BgYOY4hzUg==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.7.tgz",
+			"integrity": "sha512-I+cOG3sd/7HdFtvDSnF9QQPrWguUH7zrkIMMykM3PtfWU9soTcS2yRb9Myq6MHmzbeCT08D1UmY+BaiMl5CcoQ==",
 			"cpu": [
 				"x64"
 			],
@@ -546,9 +546,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.4.tgz",
-			"integrity": "sha512-V/NFfbWhsUU6w+m5WYbBenlEAz8eYnSqRMDMAW3K+3v0tYVkNyZn8VU0XPxk/lOqNXLSCCrV7FmV/u3SjCBShg==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.7.tgz",
+			"integrity": "sha512-om6FugwmibzfP/6ALj5WRDVSND4H2G9X0nkI1HZpp2ySf9lW2j0X68oQSaHEnls6666oy4KDsc5RFjT4m0kV0w==",
 			"cpu": [
 				"arm64"
 			],
@@ -563,9 +563,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.4.tgz",
-			"integrity": "sha512-+sPAXq3bxmFwhVFJnSwkSF5Rw2ZAJMH3MF6C9IveAEOdSpgajPhoQhbbAK12SehN9j2QrHpk4J/cHsa/HqWaYQ==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.7.tgz",
+			"integrity": "sha512-I2NvM9KPb09jWml93O2/5WMfNR7Lee5Latag1JThDRMURVhPX74p9UDnyTw3Ae6cE1DgXfw7sqQgX7rkvpc0vw==",
 			"cpu": [
 				"arm64"
 			],
@@ -580,9 +580,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.4.tgz",
-			"integrity": "sha512-R4+ZCDtG9kHArasyBO+UBD6jr/FcFCTH8QkNTOCu0pRJzCWyWC4EtZa2AmUZB5h3e0jD7bRV2KvrENcf8rndBg==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.7.tgz",
+			"integrity": "sha512-bV8/uo2Tj+gumnk4sUdkerWyCPRabaZdv88IpbmDWARQQoA/Q0YaqPz1a+LSEDIL7OfrnPi9Hq1Llz4ZIGyIQQ==",
 			"cpu": [
 				"x64"
 			],
@@ -597,9 +597,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.4.tgz",
-			"integrity": "sha512-gGvFTGpOIQDb5CQ2VC0n9Z2UEqlP46c4aNgHmAMytYieTGEcfqhfCFnhs6xjt0S3igE6q5GLuIXtdQt3Izok+g==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.7.tgz",
+			"integrity": "sha512-00kx4YrBMU8374zd2wHuRV5wseh0rom5HqRND+vDldJPrWwQw+mzd/d8byI9hPx926CG+vWzq6AeiT7Yi5y59g==",
 			"cpu": [
 				"x64"
 			],
@@ -614,9 +614,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.4.tgz",
-			"integrity": "sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.7.tgz",
+			"integrity": "sha512-hOUHBMlFCvDhu3WCq6vaBoG0dp0LkWxSEnEEsxxXvOa9TfT6ZBnbh72A/xBM7CBYB7WgwqboetzFEVDnMxelyw==",
 			"cpu": [
 				"arm64"
 			],
@@ -631,9 +631,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.4.tgz",
-			"integrity": "sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.7.tgz",
+			"integrity": "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ==",
 			"cpu": [
 				"x64"
 			],

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"zod": "4.3.6"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.4.4",
+		"@biomejs/biome": "2.4.7",
 		"@playwright/test": "1.58.2",
 		"@tailwindcss/postcss": "4.2.1",
 		"@testing-library/jest-dom": "6.9.1",


### PR DESCRIPTION
## 概要
- `@biomejs/biome` を 2.4.4 → 2.4.7 にアップデート
- `biome.json` の `$schema` を 2.4.7 に更新（`npx biome migrate --write` で自動マイグレーション）
- Dependabot PR #128 を手動対応で置き換え（schema 不整合で CI が失敗していたため）

## 変更内容
- `package.json`: `@biomejs/biome` バージョン更新
- `package-lock.json`: lockfile 更新
- `biome.json`: `$schema` URL を 2.4.7 に更新

## テスト結果
- TypeScript Check: ✅ 通過
- Unit Test: ✅ 317 passed (29 test files)
- Lint: 既存エラー数と変化なし（34 errors / 59 warnings — 今回の変更による増減なし）

## テスト計画
- [ ] CI の Lint & Format が通過すること
- [ ] 既存テストに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)