### PR TITLE
chore: vitest + @vitest/coverage-v8 を 4.1.0 にアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,14 +67,14 @@
 				"@types/react": "19.2.14",
 				"@types/react-dom": "19.2.3",
 				"@vitejs/plugin-react": "5.1.4",
-				"@vitest/coverage-v8": "4.0.18",
+				"@vitest/coverage-v8": "4.1.0",
 				"husky": "9.1.7",
 				"jsdom": "28.1.0",
 				"lint-staged": "16.3.3",
 				"tailwindcss": "4.2.1",
 				"tw-animate-css": "1.4.0",
 				"typescript": "5.9.3",
-				"vitest": "4.0.18"
+				"vitest": "4.1.0"
 			}
 		},
 		"node_modules/@acemir/cssom": {
@@ -213,6 +213,7 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -747,6 +748,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -787,6 +789,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			}
@@ -1961,6 +1964,7 @@
 			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"playwright": "1.58.2"
 			},
@@ -4059,6 +4063,7 @@
 			"resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.99.2.tgz",
 			"integrity": "sha512-179rn5wq0wBAqqGwAwR7TUGg2NOaP+fkd5FCVbYJXby85fsRNPFoNJN8YRBepqX2tN7JJcnTjqaAMXuNjiyisA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@supabase/auth-js": "2.99.2",
 				"@supabase/functions-js": "2.99.2",
@@ -4533,8 +4538,7 @@
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -4690,6 +4694,7 @@
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -4700,6 +4705,7 @@
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -4735,29 +4741,29 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
-			"integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.0.tgz",
+			"integrity": "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.0.18",
-				"ast-v8-to-istanbul": "^0.3.10",
+				"@vitest/utils": "4.1.0",
+				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
 				"istanbul-reports": "^3.2.0",
-				"magicast": "^0.5.1",
+				"magicast": "^0.5.2",
 				"obug": "^2.1.1",
-				"std-env": "^3.10.0",
+				"std-env": "^4.0.0-rc.1",
 				"tinyrainbow": "^3.0.3"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.0.18",
-				"vitest": "4.0.18"
+				"@vitest/browser": "4.1.0",
+				"vitest": "4.1.0"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -4766,17 +4772,17 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-			"integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+			"integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@standard-schema/spec": "^1.0.0",
+				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.0.18",
-				"@vitest/utils": "4.0.18",
-				"chai": "^6.2.1",
+				"@vitest/spy": "4.1.0",
+				"@vitest/utils": "4.1.0",
+				"chai": "^6.2.2",
 				"tinyrainbow": "^3.0.3"
 			},
 			"funding": {
@@ -4784,13 +4790,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-			"integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+			"integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.0.18",
+				"@vitest/spy": "4.1.0",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -4799,7 +4805,7 @@
 			},
 			"peerDependencies": {
 				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0-0"
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
 			},
 			"peerDependenciesMeta": {
 				"msw": {
@@ -4811,9 +4817,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-			"integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+			"integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4824,13 +4830,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-			"integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+			"integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.0.18",
+				"@vitest/utils": "4.1.0",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -4838,13 +4844,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-			"integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+			"integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.18",
+				"@vitest/pretty-format": "4.1.0",
+				"@vitest/utils": "4.1.0",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -4853,9 +4860,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-			"integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+			"integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -4863,13 +4870,14 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-			"integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+			"integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.18",
+				"@vitest/pretty-format": "4.1.0",
+				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.0.3"
 			},
 			"funding": {
@@ -4908,7 +4916,6 @@
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4919,7 +4926,6 @@
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -4960,9 +4966,9 @@
 			}
 		},
 		"node_modules/ast-v8-to-istanbul": {
-			"version": "0.3.12",
-			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
-			"integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+			"integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5033,6 +5039,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -5456,8 +5463,7 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/dom-helpers": {
 			"version": "5.2.1",
@@ -5480,7 +5486,8 @@
 			"version": "8.6.0",
 			"resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
 			"integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/embla-carousel-react": {
 			"version": "8.6.0",
@@ -5552,9 +5559,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5680,6 +5687,7 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -5935,6 +5943,7 @@
 			"integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@acemir/cssom": "^0.9.31",
 				"@asamuzakjp/dom-selector": "^6.8.1",
@@ -6412,7 +6421,6 @@
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -6688,6 +6696,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -6761,7 +6770,6 @@
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -6803,6 +6811,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
 			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6834,6 +6843,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
 			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -6846,8 +6856,7 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/react-refresh": {
 			"version": "0.18.0",
@@ -7264,9 +7273,9 @@
 			"license": "MIT"
 		},
 		"node_modules/std-env": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+			"integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -7454,9 +7463,9 @@
 			}
 		},
 		"node_modules/tinyrainbow": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-			"integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7698,6 +7707,7 @@
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -7812,31 +7822,32 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-			"integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+			"integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"@vitest/expect": "4.0.18",
-				"@vitest/mocker": "4.0.18",
-				"@vitest/pretty-format": "4.0.18",
-				"@vitest/runner": "4.0.18",
-				"@vitest/snapshot": "4.0.18",
-				"@vitest/spy": "4.0.18",
-				"@vitest/utils": "4.0.18",
-				"es-module-lexer": "^1.7.0",
-				"expect-type": "^1.2.2",
+				"@vitest/expect": "4.1.0",
+				"@vitest/mocker": "4.1.0",
+				"@vitest/pretty-format": "4.1.0",
+				"@vitest/runner": "4.1.0",
+				"@vitest/snapshot": "4.1.0",
+				"@vitest/spy": "4.1.0",
+				"@vitest/utils": "4.1.0",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
 				"obug": "^2.1.1",
 				"pathe": "^2.0.3",
 				"picomatch": "^4.0.3",
-				"std-env": "^3.10.0",
+				"std-env": "^4.0.0-rc.1",
 				"tinybench": "^2.9.0",
 				"tinyexec": "^1.0.2",
 				"tinyglobby": "^0.2.15",
 				"tinyrainbow": "^3.0.3",
-				"vite": "^6.0.0 || ^7.0.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -7852,12 +7863,13 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.0.18",
-				"@vitest/browser-preview": "4.0.18",
-				"@vitest/browser-webdriverio": "4.0.18",
-				"@vitest/ui": "4.0.18",
+				"@vitest/browser-playwright": "4.1.0",
+				"@vitest/browser-preview": "4.1.0",
+				"@vitest/browser-webdriverio": "4.1.0",
+				"@vitest/ui": "4.1.0",
 				"happy-dom": "*",
-				"jsdom": "*"
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
@@ -7886,6 +7898,9 @@
 				},
 				"jsdom": {
 					"optional": true
+				},
+				"vite": {
+					"optional": false
 				}
 			}
 		},
@@ -8069,6 +8084,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -78,13 +78,13 @@
 		"@types/react": "19.2.14",
 		"@types/react-dom": "19.2.3",
 		"@vitejs/plugin-react": "5.1.4",
-		"@vitest/coverage-v8": "4.0.18",
+		"@vitest/coverage-v8": "4.1.0",
 		"husky": "9.1.7",
 		"jsdom": "28.1.0",
 		"lint-staged": "16.3.3",
 		"tailwindcss": "4.2.1",
 		"tw-animate-css": "1.4.0",
 		"typescript": "5.9.3",
-		"vitest": "4.0.18"
+		"vitest": "4.1.0"
 	}
 }


### PR DESCRIPTION
## 概要
- `vitest` を 4.0.18 → 4.1.0 にアップデート
- `@vitest/coverage-v8` を 4.0.18 → 4.1.0 にアップデート
- Dependabot PR #130, #131 が Biome schema 不整合で CI 通過できなかったため、手動で対応

## 変更内容
- `package.json`: vitest, @vitest/coverage-v8 のバージョン更新
- `package-lock.json`: lockfile 更新

## テスト結果
- TypeScript Check: ✅ 通過
- Lint: ✅ 0 errors / 0 warnings
- Unit Test: ✅ 317 passed (29 test files)
- Coverage: Statements 92.09% / Branches 84.72% / Functions 100% / Lines 95.35%

## テスト計画
- [x] `npm run typecheck` 通過
- [x] `npm run lint` エラー 0 で通過
- [x] `npm run test:unit` 全通過
- [ ] CI 全チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)