### PR TITLE
fix: 勘定科目マスタ変更に伴うE2Eテスト修正

### DIFF
--- a/tests/e2e/transactions.spec.ts
+++ b/tests/e2e/transactions.spec.ts
@@ -20,13 +20,13 @@ test.describe("Transactions", () => {
 		await page.locator("#description").fill(testDescription);
 		await page.locator("#amount").fill("1000");
 
-		// Select debit account: 通信費
+		// Select debit account: Software/Cloud/SaaS (EXP001)
 		await page.locator("#debitAccount").click();
-		await page.getByRole("option", { name: "通信費" }).click();
+		await page.getByRole("option", { name: "Software/Cloud/SaaS" }).click();
 
-		// Select credit account: 普通預金
+		// Select credit account: Bank Account (AST002)
 		await page.locator("#creditAccount").click();
-		await page.getByRole("option", { name: "普通預金" }).click();
+		await page.getByRole("option", { name: "Bank Account" }).click();
 
 		await page.getByRole("button", { name: "保存" }).click();
 


### PR DESCRIPTION
## 概要

PR #155 で勘定科目マスタを Malaysia Form B 対応に変更したことにより、E2E テストの取引作成テストが失敗していた問題を修正。

refs #148

## 変更内容

- `tests/e2e/transactions.spec.ts` の勘定科目選択肢名を更新
  - 借方: `通信費` → `Software/Cloud/SaaS` (EXP001)
  - 貸方: `普通預金` → `Bank Account` (AST002)

## テスト結果

- **typecheck**: 0 errors
- **lint**: 0 issues
- **unit tests**: 341 passed
- **カバレッジ**: Statements 92.13% / Branches 84.8% / Functions 100% / Lines 95.37%

🤖 Generated with [Claude Code](https://claude.com/claude-code)