### PR TITLE
feat: PreCompact フックでコンパクション前の作業状態を自動保存

### DIFF
--- a/.claude/hooks/pre-compact.sh
+++ b/.claude/hooks/pre-compact.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+OUTPUT_FILE="$CLAUDE_PROJECT_DIR/.claude/last-session-state.md"
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+BRANCH=$(git -C "$CLAUDE_PROJECT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+{
+  echo "# Last Session State"
+  echo ""
+  echo "**Saved at:** $TIMESTAMP"
+  echo "**Branch:** $BRANCH"
+  echo ""
+  echo "## Changed Files"
+  echo ""
+  echo '```'
+  git -C "$CLAUDE_PROJECT_DIR" diff --name-only HEAD 2>/dev/null || echo "(no changes)"
+  echo '```'
+  echo ""
+  echo "## Change Stats"
+  echo ""
+  echo '```'
+  git -C "$CLAUDE_PROJECT_DIR" diff --stat HEAD 2>/dev/null || echo "(no changes)"
+  echo '```'
+  echo ""
+  echo "## Recent Commits (last 5)"
+  echo ""
+  echo '```'
+  git -C "$CLAUDE_PROJECT_DIR" log --oneline -5 2>/dev/null || echo "(no commits)"
+  echo '```'
+} > "$OUTPUT_FILE"
+
+echo '{"additionalContext": "作業状態を .claude/last-session-state.md に保存しました。コンパクション後はこのファイルを参照して作業を再開できます。"}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,17 @@
 				]
 			}
 		],
+		"PreCompact": [
+			{
+				"matcher": "",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-compact.sh"
+					}
+				]
+			}
+		],
 		"PostToolUse": [
 			{
 				"matcher": "Write|Edit",

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage/
 playwright-report/
 test-results/
 tests/e2e/.auth/
+.claude/last-session-state.md
 .env
 .env.local
 .env.*.local


### PR DESCRIPTION
## Summary

- `.claude/hooks/pre-compact.sh` を追加: コンパクション前にブランチ名・変更ファイル一覧・直近コミット5件を `.claude/last-session-state.md` に自動保存
- `.claude/settings.json` に PreCompact フックを追加
- `.gitignore` に `.claude/last-session-state.md` を追加（個人の作業状態のためGit管理外）

## Test plan

- [x] `npm run typecheck` — 型エラー 0件
- [x] `npm run lint` — Lint エラー 0件
- [x] `npm run test:unit` — 374テスト全通過
- [ ] `/compact` 実行時に `.claude/last-session-state.md` が生成されること
- [ ] 既存の PostToolUse フックが正常に動作すること

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)