### PR TITLE
feat: Stop フックでタスク完了時にユニットテストを自動実行

### DIFF
--- a/.claude/hooks/auto-test-on-stop.sh
+++ b/.claude/hooks/auto-test-on-stop.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read stdin JSON and check stop_hook_active flag (infinite loop prevention)
+STDIN=$(cat)
+STOP_HOOK_ACTIVE=$(echo "$STDIN" | grep -o '"stop_hook_active"[[:space:]]*:[[:space:]]*true' || true)
+
+if [ -n "$STOP_HOOK_ACTIVE" ]; then
+  exit 0
+fi
+
+# Get changed TypeScript files
+CHANGED_FILES=$(git diff --name-only HEAD 2>/dev/null || true)
+
+if [ -z "$CHANGED_FILES" ]; then
+  exit 0
+fi
+
+TS_FILES=$(echo "$CHANGED_FILES" | grep -E '\.(ts|tsx)$' || true)
+
+if [ -z "$TS_FILES" ]; then
+  exit 0
+fi
+
+echo "🧪 TypeScript ファイルの変更を検出。ユニットテストを自動実行..." >&2
+
+if npm run test:unit --silent 2>&1; then
+  echo "✅ ユニットテスト通過" >&2
+  exit 0
+else
+  echo "❌ ユニットテスト失敗。修正してください。" >&2
+  exit 2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,6 +61,17 @@
 				]
 			}
 		],
+		"Stop": [
+			{
+				"matcher": "",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "$CLAUDE_PROJECT_DIR/.claude/hooks/auto-test-on-stop.sh"
+					}
+				]
+			}
+		],
 		"PostToolUse": [
 			{
 				"matcher": "Write|Edit",


### PR DESCRIPTION
## Summary

- `.claude/hooks/auto-test-on-stop.sh` を追加: タスク完了時に変更された TS/TSX ファイルがあればユニットテストを自動実行
- テスト失敗時は exit 2 で Claude に続行を促す、成功時は exit 0 で正常停止
- `stop_hook_active` フラグによる無限ループ防止
- ドキュメントのみの変更ではテストをスキップ
- `.claude/settings.json` に Stop フックを追加

## Test plan

- [x] `npm run typecheck` — 型エラー 0件
- [x] `npm run lint` — Lint エラー 0件
- [x] `npm run test:unit` — 374テスト全通過
- [ ] TypeScript ファイル変更後の停止時にテストが自動実行されること
- [ ] ドキュメントのみの変更ではテストがスキップされること
- [ ] 無限ループが発生しないこと

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)