### PR TITLE
feat: claude -p 並行開発のヘルパースクリプト作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ supabase/.temp/
 .vercel
 tmp/
 .lighthouseci/
+.worktrees/

--- a/scripts/parallel-dev-cleanup.ps1
+++ b/scripts/parallel-dev-cleanup.ps1
@@ -21,6 +21,17 @@ git worktree list
 if (Test-Path $worktreeBase) {
     $dirs = Get-ChildItem -Path $worktreeBase -Directory
     foreach ($dir in $dirs) {
+        # Check for uncommitted changes
+        $status = git -C $dir.FullName status --porcelain 2>&1
+        if ($status) {
+            Write-Warning "Worktree '$($dir.FullName)' has uncommitted changes:"
+            Write-Host $status
+            $confirm = Read-Host "Remove anyway? (y/N)"
+            if ($confirm -ne "y") {
+                Write-Host "Skipped: $($dir.FullName)" -ForegroundColor Yellow
+                continue
+            }
+        }
         Write-Host "Removing worktree: $($dir.FullName)" -ForegroundColor Yellow
         git worktree remove $dir.FullName --force
     }

--- a/scripts/parallel-dev.ps1
+++ b/scripts/parallel-dev.ps1
@@ -42,6 +42,8 @@ if (-not (Test-Path $worktreeBase)) {
 
 $jobs = @()
 
+try {
+
 foreach ($issue in $IssueNumbers) {
     Write-Host "`n=== Processing Issue #$issue ===" -ForegroundColor Cyan
 
@@ -76,8 +78,9 @@ foreach ($issue in $IssueNumbers) {
     git worktree add -b $branchName $worktreePath $mainBranch
     Write-Host "Created worktree: $worktreePath (branch: $branchName)" -ForegroundColor Green
 
-    # Log file
-    $logFile = "/tmp/claude-$issue.log"
+    # Log file (use TEMP on Windows, /tmp on Unix)
+    $logDir = if ($env:TEMP) { $env:TEMP } else { "/tmp" }
+    $logFile = Join-Path $logDir "claude-$issue.log"
 
     # Launch claude -p in background
     $prompt = "gh issue view $issue で Issue の内容を確認し、/implement の手順に従って実装してください。"
@@ -128,6 +131,9 @@ foreach ($j in $jobs) {
 Write-Host "`n=== Open PRs ===" -ForegroundColor Cyan
 gh pr list --state open --author "@me"
 
-# --- Restore API key ---
-$env:ANTHROPIC_API_KEY = $originalApiKey
 Write-Host "`nDone. Run .\scripts\parallel-dev-cleanup.ps1 to clean up worktrees." -ForegroundColor Green
+
+} finally {
+    # --- Restore API key (guaranteed even on error) ---
+    $env:ANTHROPIC_API_KEY = $originalApiKey
+}

--- a/scripts/parallel-dev.sh
+++ b/scripts/parallel-dev.sh
@@ -23,6 +23,16 @@ if [[ "${1:-}" == "--cleanup" ]]; then
     if [[ -d "$WORKTREE_BASE" ]]; then
         for dir in "$WORKTREE_BASE"/*/; do
             [[ -d "$dir" ]] || continue
+            status=$(git -C "$dir" status --porcelain 2>&1 || true)
+            if [[ -n "$status" ]]; then
+                echo "WARNING: Worktree '$dir' has uncommitted changes:"
+                echo "$status"
+                read -r -p "Remove anyway? (y/N) " confirm
+                if [[ "$confirm" != "y" ]]; then
+                    echo "Skipped: $dir"
+                    continue
+                fi
+            fi
             echo "Removing worktree: $dir"
             git worktree remove "$dir" --force || true
         done
@@ -89,7 +99,7 @@ for issue in "${ISSUE_NUMBERS[@]}"; do
     }
 
     # Generate branch name
-    slug=$(echo "$issue_title" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 -]//g' | sed 's/ \+/-/g' | cut -c1-40 | sed 's/-$//')
+    slug=$(echo "$issue_title" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 -]//g' | tr -s ' ' '-' | cut -c1-40 | sed 's/-$//')
     branch_name="feature/issue-${issue}-${slug}"
 
     # Check if branch already exists


### PR DESCRIPTION
## Summary

- `scripts/parallel-dev.ps1`: Issue 番号リストから worktree 作成 → `claude -p` 並行実行を自動化（PowerShell版）
- `scripts/parallel-dev-cleanup.ps1`: worktree 削除 + main 更新のクリーンアップ（PowerShell版）
- `scripts/parallel-dev.sh`: 上記と同等の機能を bash / WSL 向けに提供（`--cleanup` オプション統合）

### Key features

- `ANTHROPIC_API_KEY` を自動無効化し、Max プランで `claude -p` を実行
- Issue タイトルからブランチ名を自動生成（`feature/issue-{number}-{slug}`）
- 各セッションのログを `/tmp/claude-{Issue番号}.log` に出力
- worktree / ブランチ既存時のエラーハンドリング

## Related Issue

closes #198

## Size justification

348 lines / 3 files — すべてシェルスクリプトのみ（TypeScript/アプリコード変更なし）。
ドキュメント・スクリプトのみの変更のため 500 行許容範囲内。

## Test plan

- [ ] `.\scripts\parallel-dev.ps1 <issue>` で worktree が作成され `claude -p` が起動すること
- [ ] `ANTHROPIC_API_KEY` が無効化されていること（Max プラン使用）
- [ ] ログが `/tmp/claude-<issue>.log` に出力されること
- [ ] worktree 既存時にエラーメッセージが表示されスキップされること
- [ ] `.\scripts\parallel-dev-cleanup.ps1` で worktree が削除されること
- [ ] `./scripts/parallel-dev.sh <issue>` で bash 版が同等に動作すること
- [ ] `./scripts/parallel-dev.sh --cleanup` でクリーンアップが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)