### PR TITLE
feat: CI 失敗時の自動修正ワークフロー導入

### DIFF
--- a/.github/workflows/ci-auto-fix.yml
+++ b/.github/workflows/ci-auto-fix.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ci-auto-fix-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
+env:
+  NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+
 jobs:
   auto-fix:
     name: Auto Fix CI Failures
@@ -32,7 +36,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const runId = context.payload.workflow_run.id;
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -50,6 +53,7 @@ jobs:
       # 2. bot コミットによる再トリガーを防止
       # --------------------------------------------------
       - name: Check last commit author
+        if: steps.pr.outcome == 'success'
         id: check-author
         uses: actions/github-script@v7
         with:
@@ -62,7 +66,13 @@ jobs:
               per_page: 1,
             });
             const lastCommitMessage = commits[0].commit.message;
-            if (lastCommitMessage.startsWith('fix: CI 失敗の自動修正')) {
+            const autoFixPatterns = [
+              'fix: CI 失敗の自動修正',
+              'fix(ci): auto-fix',
+              '[auto-fix]',
+            ];
+            const isAutoFix = autoFixPatterns.some(p => lastCommitMessage.includes(p));
+            if (isAutoFix) {
               core.setOutput('skip', 'true');
               core.info('Last commit is an auto-fix commit. Skipping to prevent loop.');
             } else {
@@ -73,7 +83,7 @@ jobs:
       # 3. 失敗ジョブのログを取得
       # --------------------------------------------------
       - name: Get failed job logs
-        if: steps.check-author.outputs.skip == 'false'
+        if: steps.pr.outcome == 'success' && steps.check-author.outputs.skip == 'false'
         id: logs
         uses: actions/github-script@v7
         with:
@@ -114,19 +124,29 @@ jobs:
             core.setOutput('failed_jobs', failedJobs.map(j => j.name).join(', '));
 
       # --------------------------------------------------
-      # 4. チェックアウト
+      # 4. チェックアウト & Node.js セットアップ
       # --------------------------------------------------
       - uses: actions/checkout@v6
-        if: steps.check-author.outputs.skip == 'false'
+        if: steps.pr.outcome == 'success' && steps.check-author.outputs.skip == 'false'
         with:
           ref: ${{ steps.pr.outputs.branch }}
           fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        if: steps.pr.outcome == 'success' && steps.check-author.outputs.skip == 'false'
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        if: steps.pr.outcome == 'success' && steps.check-author.outputs.skip == 'false'
+        run: npm ci
 
       # --------------------------------------------------
       # 5. Claude Code で自動修正
       # --------------------------------------------------
       - name: Run Claude Code Auto Fix
-        if: steps.check-author.outputs.skip == 'false'
+        if: steps.pr.outcome == 'success' && steps.check-author.outputs.skip == 'false'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -164,7 +184,7 @@ jobs:
             Bash(git diff:*)
             Bash(git add:*)
             Bash(git commit:*)
-            Bash(git push:*)
+            Bash(git push origin HEAD)
             Bash(npm run lint)
             Bash(npm run typecheck)
             Bash(npm run test:unit)


### PR DESCRIPTION
## 概要
- CI（lint, typecheck, test, build）失敗時に Claude Code が自動でエラーログを分析・修正するワークフローを追加
- `workflow_run` イベントで CI ワークフローの失敗を検知し、`anthropics/claude-code-action@v1` で修正を実行
- 修正コミットを元ブランチにプッシュし、PR コメントで修正内容を報告

## 変更内容
- `.github/workflows/ci-auto-fix.yml` を新規作成（176行）

## ガードレール
- **無限ループ防止**: auto-fix コミットメッセージ検知 + `claude-auto-fix-ci-*` ブランチ名排除
- **修正サイズ制限**: 5ファイル以上 or 50行以上の修正は中断し、分析のみ報告
- **テストファイル書き換え禁止**: プロンプトで明示的に制限
- **実行制限**: `--max-turns 20` + `timeout-minutes: 15`
- **ツール制限**: `allowedTools` で許可ツールを限定

## セットアップ（手動作業）
- GitHub Secrets に `CLAUDE_CODE_OAUTH_TOKEN` を設定する必要あり（既に `claude-assistant.yml` で使用中であれば設定済み）

## テスト結果
- ワークフローYAMLファイルのみの変更のためユニットテスト対象外
- typecheck / lint: アプリケーションコード変更なし

## テスト観点
- [ ] lint エラーを含む PR で自動修正が実行される
- [ ] 修正後に CI が通過する
- [ ] 50行以上の修正では分析のみ報告される
- [ ] auto-fix コミット後に再トリガーされない（無限ループ防止）
- [ ] テストファイルが変更されない

closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)