### PR TITLE
fix: E2E auth setup ログインボタンの strict mode violation を修正

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/bin/sh
 npx lint-staged

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -15,7 +15,7 @@ setup("authenticate", async ({ page }) => {
 
 	await page.locator("#login-email").fill(email);
 	await page.locator("#login-password").fill(password);
-	await page.getByRole("button", { name: "ログイン" }).click();
+	await page.getByRole("button", { name: "ログイン", exact: true }).click();
 
 	await page.waitForURL("**/dashboard");
 	await expect(page).toHaveURL(/\/dashboard/);

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -9,7 +9,7 @@ test.describe("Authentication", () => {
 
 		await expect(page.locator("#login-email")).toBeVisible();
 		await expect(page.locator("#login-password")).toBeVisible();
-		await expect(page.getByRole("button", { name: "ログイン" })).toBeVisible();
+		await expect(page.getByRole("button", { name: "ログイン", exact: true })).toBeVisible();
 	});
 
 	test("should login and redirect to dashboard", async ({ page }) => {
@@ -25,7 +25,7 @@ test.describe("Authentication", () => {
 
 		await page.locator("#login-email").fill(email);
 		await page.locator("#login-password").fill(password);
-		await page.getByRole("button", { name: "ログイン" }).click();
+		await page.getByRole("button", { name: "ログイン", exact: true }).click();
 
 		await page.waitForURL("**/dashboard");
 		await expect(page).toHaveURL(/\/dashboard/);


### PR DESCRIPTION
## Summary
- `getByRole('button', { name: 'ログイン' })` に `exact: true` を追加
- 「Googleでログイン」ボタン追加後、部分一致で2要素にマッチし全E2Eが失敗していた
- `.husky/pre-commit` に shebang 追加（Windows環境での実行エラー修正）

## Test plan
- [ ] CI の Playwright E2E が全テストパスすること
- [ ] マージ後、他のオープンPR（#213等）のE2Eも通るようになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)