### PR TITLE
fix: E2E transactions テストのページネーション依存を解消 (#215)

### DIFF
--- a/tests/e2e/transactions.spec.ts
+++ b/tests/e2e/transactions.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("Transactions", () => {
-	const testDescription = `E2Eテスト取引 ${Date.now()}`;
-	// Use today's date so the transaction appears on page 1 (default sort: transaction_date DESC)
-	const today = new Date().toISOString().split("T")[0] as string;
-
 	test("should create a new transaction", async ({ page }) => {
+		const testDescription = `E2Eテスト取引 ${Date.now()}`;
+		// Use today's date so the transaction appears on page 1 (default sort: transaction_date DESC)
+		const today = new Date().toISOString().split("T")[0] as string;
+
 		await page.goto("/transactions/new");
 
 		await page.locator("#transactionDate").fill(today);
@@ -34,10 +34,11 @@ test.describe("Transactions", () => {
 		await Promise.race([redirected, errorShown]);
 		await expect(page).toHaveURL(/\/transactions/);
 
-		// Wait for revalidation and reload to ensure fresh data
-		await page.reload({ waitUntil: "networkidle" });
+		// Navigate to transactions list with search filter to avoid pagination issues
+		await page.goto(`/transactions?search=${encodeURIComponent(testDescription)}`);
+		await page.waitForLoadState("networkidle");
 
-		// Verify the created transaction appears in the list
+		// Verify the created transaction appears in the filtered list
 		await expect(page.getByText(testDescription)).toBeVisible({ timeout: 15000 });
 
 		// Cleanup: delete the created test transaction


### PR DESCRIPTION
## Summary
- 取引作成後に検索フィルタ付きURL (`/transactions?search=...`) で一覧を開くことで、ページネーションに依存せず確実に作成した取引を検出
- `testDescription` をテストケース内で定義し、各ブラウザ/リトライで一意のタイムスタンプを生成

## 根本原因
E2Eテスト失敗時にクリーンアップがスキップされ、テスト用アカウントにゴミ取引が蓄積。`perPage: 20` のページネーションで新規作成した取引が2ページ目以降に押し出されていた。

## Test plan
- [ ] CI の Playwright E2E が全ブラウザでパスすること
- [ ] `npm run typecheck` / `npm run lint` / `npm run test:unit` パス確認済み

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)